### PR TITLE
[0.0.3] - Static Site Preliminary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .env
 
 reference-docs/
+AGENTS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable curriculum-documentation changes in this repo should be recorded her
 
 ## Unreleased
 
+## [0.0.3] - Static Site Preliminary
+
+### Added
+
+- Added a dependency-free GitHub Pages onboarding site under [docs/index.html](docs/index.html), with static CSS and JavaScript assets in [docs/assets/](docs/assets/).
+- Added cohort-facing sections for registration, program positioning, selection and onboarding flow, expected outputs, responsible AI use, organizing team, and FAQs.
+
 ## [0.0.2] - Leveraging AI Guide
 
 ### Added

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -1,0 +1,654 @@
+:root {
+  --color-primary: #080808;
+  --color-canvas: #ffffff;
+  --color-hairline: #d8d8d8;
+  --color-ink: #080808;
+  --color-body: #363636;
+  --color-body-mid: #5a5a5a;
+  --color-mute: #898989;
+  --color-purple: #7a3dff;
+  --color-pink: #ed52cb;
+  --color-blue: #3b89ff;
+  --color-blue-deep: #006acc;
+  --color-orange: #ff6b00;
+  --color-green: #00d722;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --shadow-layered: 0 84px 24px rgba(0, 0, 0, 0),
+    0 54px 22px rgba(0, 0, 0, 0.01),
+    0 30px 18px rgba(0, 0, 0, 0.04),
+    0 13px 13px rgba(0, 0, 0, 0.08),
+    0 3px 7px rgba(0, 0, 0, 0.09);
+  --container: 1180px;
+  --gutter: clamp(20px, 4vw, 48px);
+  --section-y: clamp(64px, 9vw, 120px);
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  color: var(--color-blue-deep);
+}
+
+.skip-link {
+  background: var(--color-primary);
+  color: var(--color-canvas);
+  left: 16px;
+  padding: 10px 14px;
+  position: fixed;
+  top: -80px;
+  z-index: 20;
+}
+
+.skip-link:focus {
+  top: 16px;
+}
+
+.site-header {
+  background: rgba(255, 255, 255, 0.94);
+  border-bottom: 1px solid var(--color-hairline);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.nav {
+  align-items: center;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: calc(var(--container) + var(--gutter) * 2);
+  padding: 16px var(--gutter);
+}
+
+.brand {
+  align-items: center;
+  display: inline-flex;
+  font-weight: 600;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.brand-mark {
+  align-items: center;
+  background: var(--color-primary);
+  border-radius: var(--radius-sm);
+  color: var(--color-canvas);
+  display: inline-flex;
+  font-size: 12px;
+  height: 32px;
+  justify-content: center;
+  letter-spacing: 0.6px;
+  width: 42px;
+}
+
+.brand-text {
+  font-size: 15px;
+}
+
+.nav-links {
+  align-items: center;
+  display: flex;
+  gap: 20px;
+}
+
+.nav-links a {
+  color: var(--color-ink);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.nav-links a[aria-current="true"] {
+  color: var(--color-blue-deep);
+}
+
+.nav-links .nav-cta {
+  background: var(--color-primary);
+  border-radius: var(--radius-sm);
+  color: var(--color-canvas);
+  padding: 10px 14px;
+}
+
+.nav-toggle {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-sm);
+  display: none;
+  height: 42px;
+  padding: 9px;
+  width: 42px;
+}
+
+.nav-toggle-bar {
+  background: var(--color-primary);
+  display: block;
+  height: 2px;
+  margin: 4px 0;
+  width: 100%;
+}
+
+.sr-only {
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
+.hero {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+  margin: 0 auto;
+  max-width: calc(var(--container) + var(--gutter) * 2);
+  min-height: calc(100vh - 72px);
+  padding: clamp(56px, 8vw, 112px) var(--gutter) 48px;
+}
+
+.hero-copy {
+  align-self: center;
+}
+
+.eyebrow {
+  color: var(--color-body-mid);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 1.5px;
+  margin: 0 0 16px;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  font-size: clamp(48px, 7.2vw, 80px);
+  font-weight: 600;
+  letter-spacing: -0.8px;
+  line-height: 1.04;
+  margin-bottom: 24px;
+  max-width: 920px;
+}
+
+h2 {
+  font-size: clamp(34px, 5vw, 56px);
+  font-weight: 600;
+  line-height: 1.08;
+  margin-bottom: 0;
+}
+
+h3 {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.4;
+  margin-bottom: 12px;
+}
+
+.hero-lede {
+  color: var(--color-body);
+  font-size: clamp(22px, 3vw, 29px);
+  line-height: 1.6;
+  margin-bottom: 32px;
+  max-width: 760px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.button {
+  align-items: center;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  font-weight: 500;
+  justify-content: center;
+  min-height: 48px;
+  padding: 11px 20px;
+  text-decoration: none;
+}
+
+.button-primary {
+  background: var(--color-primary);
+  color: var(--color-canvas);
+}
+
+.button-primary:hover {
+  color: var(--color-canvas);
+}
+
+.button-secondary {
+  background: var(--color-canvas);
+  border: 1px solid var(--color-hairline);
+  color: var(--color-ink);
+}
+
+.hero-panel {
+  align-self: end;
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-layered);
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  overflow: hidden;
+}
+
+.metric {
+  border-bottom: 1px solid var(--color-hairline);
+  border-right: 1px solid var(--color-hairline);
+  min-height: 150px;
+  padding: 24px;
+}
+
+.metric:nth-child(2n) {
+  border-right: 0;
+}
+
+.metric:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.metric-value,
+.metric-label {
+  display: block;
+}
+
+.metric-value {
+  font-size: clamp(32px, 4vw, 48px);
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1;
+  margin-bottom: 12px;
+}
+
+.metric-label {
+  color: var(--color-body-mid);
+  font-size: 14px;
+}
+
+.content-band {
+  margin: 0 auto;
+  max-width: calc(var(--container) + var(--gutter) * 2);
+  padding: var(--section-y) var(--gutter);
+}
+
+.section-heading {
+  margin-bottom: 36px;
+  max-width: 780px;
+}
+
+.feature-grid,
+.ai-grid,
+.team-grid,
+.category-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.feature-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.feature-card,
+.notice-card,
+.team-group,
+.timeline-item {
+  border: 1px solid var(--color-hairline);
+  border-radius: var(--radius-md);
+  padding: 28px;
+}
+
+.feature-card p,
+.notice-card p,
+.timeline-item p,
+.category-card p {
+  color: var(--color-body);
+  margin-bottom: 0;
+}
+
+.feature-card-dark {
+  background: var(--color-primary);
+  color: var(--color-canvas);
+}
+
+.feature-card-dark p {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.timeline {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.step-number {
+  color: var(--color-blue-deep);
+  display: block;
+  font-size: 13px;
+  font-weight: 550;
+  letter-spacing: 0.6px;
+  margin-bottom: 18px;
+}
+
+.notice-card {
+  background: var(--color-primary);
+  box-shadow: var(--shadow-layered);
+  color: var(--color-canvas);
+  margin-top: 16px;
+}
+
+.notice-card p {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.category-grid {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+.category-card {
+  border-radius: var(--radius-md);
+  color: var(--color-canvas);
+  min-height: 230px;
+  padding: 28px;
+}
+
+.category-card:nth-child(1),
+.category-card:nth-child(2) {
+  grid-column: span 3;
+}
+
+.category-card:nth-child(n + 3) {
+  grid-column: span 2;
+}
+
+.category-card.purple {
+  background: var(--color-purple);
+}
+
+.category-card.pink {
+  background: var(--color-pink);
+}
+
+.category-card.blue {
+  background: var(--color-blue);
+}
+
+.category-card.orange {
+  background: var(--color-orange);
+}
+
+.category-card.green {
+  background: var(--color-green);
+  color: var(--color-primary);
+}
+
+.category-card p {
+  color: currentColor;
+}
+
+.ai-band {
+  border-bottom: 1px solid var(--color-hairline);
+  border-top: 1px solid var(--color-hairline);
+}
+
+.ai-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.check-list {
+  color: var(--color-body);
+  margin: 0;
+  padding-left: 20px;
+}
+
+.check-list li + li {
+  margin-top: 8px;
+}
+
+.text-link {
+  display: inline-flex;
+  font-weight: 500;
+  margin-top: 28px;
+  text-underline-offset: 5px;
+}
+
+.team-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.team-group ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.team-group li + li {
+  border-top: 1px solid var(--color-hairline);
+  margin-top: 14px;
+  padding-top: 14px;
+}
+
+.team-group span,
+.team-group small {
+  display: block;
+}
+
+.team-group span {
+  font-weight: 500;
+}
+
+.team-group small {
+  color: var(--color-body-mid);
+  font-size: 13px;
+  line-height: 1.45;
+  margin-top: 3px;
+}
+
+.faq-list {
+  border-top: 1px solid var(--color-hairline);
+}
+
+.faq-list details {
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 20px 0;
+}
+
+.faq-list summary {
+  cursor: pointer;
+  font-size: 20px;
+  font-weight: 500;
+  list-style: none;
+}
+
+.faq-list summary::-webkit-details-marker {
+  display: none;
+}
+
+.faq-list summary::after {
+  content: "+";
+  float: right;
+  font-size: 24px;
+  line-height: 1;
+}
+
+.faq-list details[open] summary::after {
+  content: "-";
+}
+
+.faq-list p {
+  color: var(--color-body);
+  margin: 14px 0 0;
+  max-width: 760px;
+}
+
+.footer {
+  align-items: flex-start;
+  border-top: 1px solid var(--color-hairline);
+  color: var(--color-body-mid);
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin: 0 auto;
+  max-width: calc(var(--container) + var(--gutter) * 2);
+  padding: 32px var(--gutter);
+}
+
+.footer p {
+  margin-bottom: 0;
+}
+
+.footer-title {
+  color: var(--color-ink);
+  font-weight: 500;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.footer-links a {
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+@media (max-width: 991px) {
+  .hero,
+  .feature-grid,
+  .timeline,
+  .team-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hero-copy {
+    grid-column: 1 / -1;
+  }
+
+  .category-card:nth-child(n) {
+    grid-column: span 3;
+  }
+}
+
+@media (max-width: 767px) {
+  .nav {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .nav-toggle {
+    display: inline-block;
+  }
+
+  .nav-links {
+    display: none;
+    flex-basis: 100%;
+    flex-direction: column;
+    gap: 8px;
+    padding-top: 12px;
+  }
+
+  .nav-links.is-open {
+    display: flex;
+  }
+
+  .nav-links a {
+    border: 1px solid var(--color-hairline);
+    border-radius: var(--radius-sm);
+    display: block;
+    padding: 10px 12px;
+    width: 100%;
+  }
+
+  .nav-links .nav-cta {
+    text-align: center;
+  }
+
+  .hero,
+  .feature-grid,
+  .timeline,
+  .ai-grid,
+  .team-grid,
+  .category-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    min-height: auto;
+  }
+
+  .hero-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .metric,
+  .metric:nth-child(2n),
+  .metric:nth-last-child(-n + 2) {
+    border-bottom: 1px solid var(--color-hairline);
+    border-right: 0;
+    min-height: 124px;
+  }
+
+  .metric:last-child {
+    border-bottom: 0;
+  }
+
+  .category-card:nth-child(n) {
+    grid-column: auto;
+  }
+
+  .footer {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 479px) {
+  .brand-text {
+    max-width: 170px;
+  }
+
+  .hero-actions,
+  .button {
+    width: 100%;
+  }
+
+  .feature-card,
+  .notice-card,
+  .team-group,
+  .timeline-item,
+  .category-card {
+    padding: 22px;
+  }
+}

--- a/docs/assets/site.js
+++ b/docs/assets/site.js
@@ -1,0 +1,46 @@
+const navToggle = document.querySelector(".nav-toggle");
+const navLinks = document.querySelector("#nav-links");
+
+if (navToggle && navLinks) {
+  navToggle.addEventListener("click", () => {
+    const isOpen = navLinks.classList.toggle("is-open");
+    navToggle.setAttribute("aria-expanded", String(isOpen));
+  });
+
+  navLinks.addEventListener("click", (event) => {
+    if (event.target instanceof HTMLAnchorElement) {
+      navLinks.classList.remove("is-open");
+      navToggle.setAttribute("aria-expanded", "false");
+    }
+  });
+}
+
+const observedSections = document.querySelectorAll("main section[id]");
+const navAnchors = document.querySelectorAll('.nav-links a[href^="#"]');
+
+if ("IntersectionObserver" in window && observedSections.length > 0) {
+  const observer = new IntersectionObserver(
+    (entries) => {
+      const visible = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+
+      if (!visible) {
+        return;
+      }
+
+      navAnchors.forEach((anchor) => {
+        anchor.toggleAttribute(
+          "aria-current",
+          anchor.getAttribute("href") === `#${visible.target.id}`,
+        );
+      });
+    },
+    {
+      rootMargin: "-30% 0px -55% 0px",
+      threshold: [0.1, 0.3, 0.6],
+    },
+  );
+
+  observedSections.forEach((section) => observer.observe(section));
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,382 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta
+      name="description"
+      content="Onboarding site for the DEP Engineering Foundations (Open Track) 2026 Cohort, a community-powered build sprint by Data Engineering Pilipinas."
+    >
+    <title>DEP Engineering Foundations (Open Track) - 2026 Cohort</title>
+    <link rel="stylesheet" href="assets/site.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <nav class="nav" aria-label="Primary navigation">
+        <a class="brand" href="#top" aria-label="DEP Engineering Foundations home">
+          <span class="brand-mark" aria-hidden="true">DEP</span>
+          <span class="brand-text">Engineering Foundations</span>
+        </a>
+
+        <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="nav-links">
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="nav-toggle-bar"></span>
+          <span class="sr-only">Open navigation</span>
+        </button>
+
+        <div class="nav-links" id="nav-links">
+          <a href="#about">About</a>
+          <a href="#process">Process</a>
+          <a href="#outputs">Outputs</a>
+          <a href="#ai">AI</a>
+          <a href="#team">Team</a>
+          <a href="#faq">FAQ</a>
+          <a class="nav-cta" href="#register">Register</a>
+        </div>
+      </nav>
+    </header>
+
+    <main id="main">
+      <section class="hero" id="top" aria-labelledby="hero-title">
+        <div class="hero-copy">
+          <p class="eyebrow">2026 Cohort / June to November</p>
+          <h1 id="hero-title">DEP Engineering Foundations (Open Track) - 2026 Cohort</h1>
+          <p class="hero-lede">
+            A 6-month, community-powered build sprint for aspiring data builders.
+          </p>
+          <div class="hero-actions" id="register">
+            <a
+              class="button button-primary"
+              href="https://docs.google.com/forms/d/e/1FAIpQLSeGnmZuWDwweTzPi6K9m_3YDVNNVfNntFtc2H8OS0JDXMV-1Q/viewform"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Register for the cohort
+            </a>
+            <a
+              class="button button-secondary"
+              href="https://github.com/dataengineeringpilipinas/dep-data-engineering-open-track"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View curriculum repo
+            </a>
+          </div>
+        </div>
+
+        <aside class="hero-panel" aria-label="Cohort facts">
+          <div class="metric">
+            <span class="metric-value">700+</span>
+            <span class="metric-label">Applicants</span>
+          </div>
+          <div class="metric">
+            <span class="metric-value">24</span>
+            <span class="metric-label">Weeks</span>
+          </div>
+          <div class="metric">
+            <span class="metric-value">5 hrs</span>
+            <span class="metric-label">Weekly pace</span>
+          </div>
+          <div class="metric">
+            <span class="metric-value">Free</span>
+            <span class="metric-label">Community-led</span>
+          </div>
+        </aside>
+      </section>
+
+      <section class="content-band" id="about" aria-labelledby="about-title">
+        <div class="section-heading">
+          <p class="eyebrow">What this is</p>
+          <h2 id="about-title">Not a bootcamp. A build sprint.</h2>
+        </div>
+
+        <div class="feature-grid">
+          <article class="feature-card feature-card-dark">
+            <h3>Community-powered</h3>
+            <p>
+              Builders work through an open curriculum with milestone support from volunteers,
+              reviewers, moderators, squad guides, and project mentors.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Project-driven</h3>
+            <p>
+              Each participant builds a public GitHub project, an end-to-end data pipeline,
+              and a deployed dashboard that can be shown beyond the cohort.
+            </p>
+          </article>
+          <article class="feature-card">
+            <h3>Led by DEP</h3>
+            <p>
+              This initiative is led by the leadership team of
+              <a href="https://dataengineering.ph/about.html" target="_blank" rel="noopener noreferrer">
+                Data Engineering Pilipinas
+              </a>,
+              a DataCamp Donates Partner.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-band" id="process" aria-labelledby="process-title">
+        <div class="section-heading">
+          <p class="eyebrow">How the cohort works</p>
+          <h2 id="process-title">From application to program launch</h2>
+        </div>
+
+        <div class="timeline" aria-label="Cohort onboarding flow">
+          <article class="timeline-item">
+            <span class="step-number">01</span>
+            <h3>Selection</h3>
+            <p>Applications are reviewed by the admissions panel against cohort fit and readiness.</p>
+          </article>
+          <article class="timeline-item">
+            <span class="step-number">02</span>
+            <h3>Selection announcement</h3>
+            <p>Selected builders receive cohort instructions, next steps, and onboarding details.</p>
+          </article>
+          <article class="timeline-item">
+            <span class="step-number">03</span>
+            <h3>Meetup and onboarding</h3>
+            <p>The cohort meets the organizing team, support team, operating rhythm, and curriculum flow.</p>
+          </article>
+          <article class="timeline-item">
+            <span class="step-number">04</span>
+            <h3>GitHub onboarding</h3>
+            <p>Builders set up GitHub, fork or create their project repo, and submit the required repo link.</p>
+          </article>
+          <article class="timeline-item">
+            <span class="step-number">05</span>
+            <h3>Cohort channel and check-ins</h3>
+            <p>A dedicated channel anchors questions, updates, and regular check-ins led by James.</p>
+          </article>
+          <article class="timeline-item">
+            <span class="step-number">06</span>
+            <h3>Program start declaration</h3>
+            <p>The team confirms support coverage, reviews expected outputs, and officially starts the build sprint.</p>
+          </article>
+        </div>
+
+        <div class="notice-card">
+          <h3>Open-track fallback</h3>
+          <p>
+            Applicants who are not selected for direct support may still follow the public GitHub curriculum
+            independently. The repo remains free, open, and usable without cohort admission.
+          </p>
+        </div>
+      </section>
+
+      <section class="content-band" id="outputs" aria-labelledby="outputs-title">
+        <div class="section-heading">
+          <p class="eyebrow">Expected outputs</p>
+          <h2 id="outputs-title">What builders will produce</h2>
+        </div>
+
+        <div class="category-grid">
+          <article class="category-card purple">
+            <h3>Public GitHub repo</h3>
+            <p>A clean, documented project repository with setup notes, source code, and project context.</p>
+          </article>
+          <article class="category-card pink">
+            <h3>Data pipeline</h3>
+            <p>An ingestion, cleaning, analysis, and validation flow using free and open-source tools.</p>
+          </article>
+          <article class="category-card blue">
+            <h3>Milestone submissions</h3>
+            <p>Seven milestone outputs from problem framing through final deployment.</p>
+          </article>
+          <article class="category-card orange">
+            <h3>Launching meet readiness</h3>
+            <p>Clear expectations for the infrastructure, GitHub workflow, and project tech stack.</p>
+          </article>
+          <article class="category-card green">
+            <h3>Live dashboard</h3>
+            <p>A GitHub Pages deployment that turns the final analysis into a shareable project artifact.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-band ai-band" id="ai" aria-labelledby="ai-title">
+        <div class="section-heading">
+          <p class="eyebrow">Responsible AI</p>
+          <h2 id="ai-title">Use AI as a coach, not a substitute.</h2>
+        </div>
+
+        <div class="ai-grid">
+          <article class="feature-card">
+            <h3>Good uses</h3>
+            <ul class="check-list">
+              <li>Brainstorm project questions and data sources.</li>
+              <li>Explain Python, Git, SQL, and data concepts.</li>
+              <li>Debug errors and review drafts against milestone checklists.</li>
+              <li>Improve clarity after you have written your own attempt.</li>
+            </ul>
+          </article>
+          <article class="feature-card">
+            <h3>Boundaries</h3>
+            <ul class="check-list">
+              <li>Do not invent sources, metrics, results, or conclusions.</li>
+              <li>Do not submit work you cannot explain live.</li>
+              <li>Do not use AI to bypass milestone rules or reviewer checks.</li>
+              <li>Do not hide missing work behind polished wording.</li>
+            </ul>
+          </article>
+        </div>
+
+        <a class="text-link" href="AI_GUIDE.md">Read the full AI guide</a>
+      </section>
+
+      <section class="content-band" id="team" aria-labelledby="team-title">
+        <div class="section-heading">
+          <p class="eyebrow">Organizing team</p>
+          <h2 id="team-title">The people supporting the 2026 cohort</h2>
+        </div>
+
+        <div class="team-grid">
+          <article class="team-group">
+            <h3>Program</h3>
+            <ul>
+              <li><span>Katherine Bulac</span><small>Program Lead / Admission Panel</small></li>
+              <li><span>Bea Lambitco</span><small>Program Lead Support</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Ops</h3>
+            <ul>
+              <li><span>James David Bradly Carballo</span><small>Ops Lead</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Systems</h3>
+            <ul>
+              <li><span>Raymond Cancino</span><small>Systems Lead</small></li>
+              <li><span>JC Diamante</span><small>Systems Lead Support</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Curriculum</h3>
+            <ul>
+              <li><span>Nina Comia</span><small>Curriculum Lead</small></li>
+              <li><span>CJ Maminta</span><small>Curriculum Lead Support</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Communications</h3>
+            <ul>
+              <li><span>Anam Iqbal</span><small>Comms Lead / Admission Panel</small></li>
+              <li><span>Keith Tidon</span><small>Comms Lead Support</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Milestone Review</h3>
+            <ul>
+              <li><span>Jomai Hizon</span><small>Milestone Reviewer Lead</small></li>
+              <li><span>Kim Audrey Magan</span><small>Milestone Reviewer</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Community</h3>
+            <ul>
+              <li><span>Marc Sandrino</span><small>Community Moderator Lead</small></li>
+              <li><span>Nick Estole</span><small>Community Moderator</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Content</h3>
+            <ul>
+              <li><span>Zierd Ethan</span><small>Content Curator Lead / Squad Guide</small></li>
+              <li><span>Andrei Marcus</span><small>Content Curator</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Squad Guides</h3>
+            <ul>
+              <li><span>Yui Otsuka</span><small>Squad Guide Lead / Project Mentor</small></li>
+              <li><span>Vanie Bermudez</span><small>Squad Guide / Admission Panel</small></li>
+              <li><span>Renzi Vidal</span><small>Squad Guide / Project Mentor</small></li>
+              <li><span>Zierd Ethan</span><small>Squad Guide</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Project Mentors</h3>
+            <ul>
+              <li><span>Macky Sunga</span><small>Project Mentor Lead</small></li>
+              <li><span>Yui Otsuka</span><small>Project Mentor</small></li>
+              <li><span>Renzi Vidal</span><small>Project Mentor</small></li>
+              <li><span>Joma Miñoza</span><small>Project Mentor</small></li>
+              <li><span>Marco Francisco</span><small>Project Mentor</small></li>
+            </ul>
+          </article>
+          <article class="team-group">
+            <h3>Admissions</h3>
+            <ul>
+              <li><span>Katherine Bulac</span><small>Admission Panel</small></li>
+              <li><span>Anam Iqbal</span><small>Admission Panel</small></li>
+              <li><span>Vanie Bermudez</span><small>Admission Panel</small></li>
+              <li><span>Renan Matthew Fajardo</span><small>Admission Panel</small></li>
+            </ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="content-band" id="faq" aria-labelledby="faq-title">
+        <div class="section-heading">
+          <p class="eyebrow">FAQ</p>
+          <h2 id="faq-title">Questions builders usually ask</h2>
+        </div>
+
+        <div class="faq-list">
+          <details>
+            <summary>Do I need prior experience?</summary>
+            <p>No. You need basic Python familiarity, a willingness to work through blockers, and the discipline to keep your repo updated.</p>
+          </details>
+          <details>
+            <summary>What tools do I need?</summary>
+            <p>Python 3.10 or newer, Git, a GitHub account, and a code editor such as VS Code. The program uses free and open-source tools.</p>
+          </details>
+          <details>
+            <summary>Is this free?</summary>
+            <p>Yes. The cohort and public curriculum are free. The program is supported by the Data Engineering Pilipinas community.</p>
+          </details>
+          <details>
+            <summary>How does selection work?</summary>
+            <p>The admissions panel reviews applications, announces selected builders, and provides onboarding instructions before the program starts.</p>
+          </details>
+          <details>
+            <summary>What if I miss a milestone?</summary>
+            <p>Milestones are reviewed against the published checklist. If you are blocked, follow the stuck protocol and ask for help early in the cohort channel.</p>
+          </details>
+          <details>
+            <summary>Can I use my own dataset?</summary>
+            <p>Yes. The program is designed around your question, your audience, and your dataset, as long as the scope is feasible for the 24-week build sprint.</p>
+          </details>
+          <details>
+            <summary>Can I use AI while working on the program?</summary>
+            <p>Yes. Use AI as a coach for brainstorming, explanation, debugging, and review. Do not use it to invent results or replace your own understanding.</p>
+          </details>
+          <details>
+            <summary>What if I am not selected?</summary>
+            <p>You can still follow the public GitHub curriculum independently. Direct team support is reserved for selected builders in the supported cohort.</p>
+          </details>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div>
+        <p class="footer-title">DEP Engineering Foundations (Open Track)</p>
+        <p>Built by Data Engineering Pilipinas. Free and open. Always.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://github.com/dataengineeringpilipinas/dep-data-engineering-open-track" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a href="https://dataengineering.ph/about.html" target="_blank" rel="noopener noreferrer">About DEP</a>
+        <a href="FAQ.md">FAQ.md</a>
+      </div>
+    </footer>
+
+    <script src="assets/site.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## [0.0.3] - Static Site Preliminary

### Added

- Added a dependency-free GitHub Pages onboarding site under [docs/index.html](docs/index.html), with static CSS and JavaScript assets in [docs/assets/](docs/assets/).
- Added cohort-facing sections for registration, program positioning, selection and onboarding flow, expected outputs, responsible AI use, organizing team, and FAQs.
