### PR TITLE
[0.1.0] - CI Milestone Check fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/milestone-m0.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m0.yml
@@ -35,6 +35,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/ISSUE_TEMPLATE/milestone-m1.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m1.yml
@@ -36,6 +36,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/ISSUE_TEMPLATE/milestone-m2.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m2.yml
@@ -35,6 +35,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/ISSUE_TEMPLATE/milestone-m3.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m3.yml
@@ -35,6 +35,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/ISSUE_TEMPLATE/milestone-m4.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m4.yml
@@ -35,6 +35,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/ISSUE_TEMPLATE/milestone-m5.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m5.yml
@@ -36,6 +36,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/ISSUE_TEMPLATE/milestone-m6.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m6.yml
@@ -36,6 +36,8 @@ body:
       placeholder: "https://github.com/<your-username>/dep-starter-kit"
     validations:
       required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
 
   - type: input
     id: commit_hash

--- a/.github/workflows/milestone-check.yml
+++ b/.github/workflows/milestone-check.yml
@@ -63,6 +63,15 @@ jobs:
             const prevMilestone = MILESTONES[idx - 1];
             core.setOutput('prev_milestone', prevMilestone);
 
+            // Normalise repo URL to base owner/repo (handles blob/tree/file URLs)
+            const urlMatch = repoUrl.match(/(https?:\/\/github\.com\/[\w.-]+\/[\w.-]+?)(?:\.git)?(?:\/|$)/);
+            const baseUrl = urlMatch ? urlMatch[1] : null;
+
+            if (!baseUrl) {
+              core.setOutput('gate_ok', 'false');
+              return;
+            }
+
             // Find all passed issues for the previous milestone
             const issues = await github.paginate(github.rest.issues.listForRepo, {
               owner: context.repo.owner,
@@ -71,7 +80,7 @@ jobs:
               state: 'all'
             });
 
-            const found = issues.some(issue => issue.body && issue.body.includes(repoUrl));
+            const found = issues.some(issue => issue.body && issue.body.includes(baseUrl));
             core.setOutput('gate_ok', found ? 'true' : 'false');
 
       - name: Block if prerequisite not met
@@ -254,6 +263,18 @@ jobs:
               const builderName = (context.payload.issue.body || '').match(/###\s+Builder Name\s*\n+([^\n#]+)/i)?.[1]?.trim() || context.payload.issue.user.login;
               const cohort      = (context.payload.issue.body || '').match(/###\s+Cohort\s*\n+([^\n#]+)/i)?.[1]?.trim() || '—';
               const repoUrl     = '${{ steps.parse.outputs.repo_url }}';
+
+              // Auto-apply passed label for M0 (purely structural checks — no subjective review needed)
+              if (milestone === 'M0') {
+                try {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.payload.issue.number,
+                    labels: ['passed']
+                  });
+                } catch (_) {}
+              }
 
               // Only notify Discord for enrolled participants
               const enrolledRes = await fetch(`https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/main/.github/enrolled-participants.json`);

--- a/.github/workflows/milestone-recheck.yml
+++ b/.github/workflows/milestone-recheck.yml
@@ -47,7 +47,11 @@ jobs:
 
             // Extract repo URL from original issue body
             const repoMatch = issueBody.match(/###\s+GitHub Repo URL\s*\n+([^\n#]+)/i);
-            const repoUrl = repoMatch ? repoMatch[1].trim() : '';
+            const rawUrl = repoMatch ? repoMatch[1].trim() : '';
+
+            // Normalise to base repo URL (handles blob/tree/file URLs)
+            const urlMatch = rawUrl.match(/(https?:\/\/github\.com\/[\w.-]+\/[\w.-]+?)(?:\.git)?(?:\/|$)/);
+            const repoUrl = urlMatch ? urlMatch[1] : rawUrl;
             core.setOutput('repo_url', repoUrl);
 
       - name: Skip if no commit hash in comment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable curriculum-documentation changes in this repo should be recorded here.
 
-## Unreleased
+## [0.1.0] - CI Milestone Check fixes
+
+### Fixed
+
+- **Gate URL matching in milestone-check.yml**: Normalizes repo URLs to base `owner/repo` before comparing. Previously, if a builder pasted a blob/tree URL (e.g. `.../blob/main/file`) in the "GitHub Repo URL" field, the gate check would fail to find their passed M0 submission because the substring match used the raw (wrong) URL.
+- **Clone URL normalization in milestone-recheck.yml**: Same normalization applied to repo URLs on resubmission so `git clone` works even when the original issue body has a blob/file URL.
+
+### Added
+
+- **URL pattern validation on all milestone issue templates (M0-M6)**: The "GitHub Repo URL" field now rejects blob/tree/file URLs with a clear mismatch message, guiding builders to enter the repo root URL.
+- **Auto-apply `passed` label for M0**: When all M0 structural checks pass, the `passed` label is applied automatically. M0 checks are purely structural (README existence and content length), so no subjective review is needed — this removes the manual bottleneck before builders can proceed to M1.
 
 ## [0.0.7] - Organizing Team Pictures
 


### PR DESCRIPTION
## [0.1.0] - CI Milestone Check fixes

### Fixed

- **Gate URL matching in milestone-check.yml**: Normalizes repo URLs to base `owner/repo` before comparing. Previously, if a builder pasted a blob/tree URL (e.g. `.../blob/main/file`) in the "GitHub Repo URL" field, the gate check would fail to find their passed M0 submission because the substring match used the raw (wrong) URL.
- **Clone URL normalization in milestone-recheck.yml**: Same normalization applied to repo URLs on resubmission so `git clone` works even when the original issue body has a blob/file URL.

### Added

- **URL pattern validation on all milestone issue templates (M0-M6)**: The "GitHub Repo URL" field now rejects blob/tree/file URLs with a clear mismatch message, guiding builders to enter the repo root URL.
- **Auto-apply `passed` label for M0**: When all M0 structural checks pass, the `passed` label is applied automatically. M0 checks are purely structural (README existence and content length), so no subjective review is needed — this removes the manual bottleneck before builders can proceed to M1.