### PR TITLE
fix(ci): preserve on-time milestone submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/milestone-m0.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m0.yml
@@ -8,6 +8,8 @@ body:
       value: |
         **Milestone 0 — Project Proposal**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
+        Submit once before the deadline. If changes are requested, comment `/recheck <40-character-hash>` on this same issue instead of opening another one.
+        Automated checks verify the repository snapshot; a human reviewer makes the final M0 verdict.
 
   - type: input
     id: builder_name

--- a/.github/ISSUE_TEMPLATE/milestone-m1.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m1.yml
@@ -9,6 +9,8 @@ body:
         **Milestone 1 — Foundations Complete**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
         M1 is a **hard gate** — moderator review required before you proceed to Phase 2.
+        If M0 is still awaiting review, an on-time M1 issue stays open in the prerequisite queue and releases automatically after M0 passes.
+        Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input
     id: builder_name

--- a/.github/ISSUE_TEMPLATE/milestone-m2.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m2.yml
@@ -8,6 +8,8 @@ body:
       value: |
         **Milestone 2 — Data Ingestion**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
+        If M1 is still awaiting review, an on-time M2 issue stays open in the prerequisite queue and releases automatically after M1 passes.
+        Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input
     id: builder_name

--- a/.github/ISSUE_TEMPLATE/milestone-m3.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m3.yml
@@ -8,6 +8,8 @@ body:
       value: |
         **Milestone 3 — Data Processing**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
+        If M2 is still awaiting review, an on-time M3 issue stays open in the prerequisite queue and releases automatically after M2 passes.
+        Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input
     id: builder_name

--- a/.github/ISSUE_TEMPLATE/milestone-m4.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m4.yml
@@ -8,6 +8,8 @@ body:
       value: |
         **Milestone 4 — Analysis & Insights**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
+        If M3 is still awaiting review, an on-time M4 issue stays open in the prerequisite queue and releases automatically after M3 passes.
+        Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input
     id: builder_name

--- a/.github/ISSUE_TEMPLATE/milestone-m5.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m5.yml
@@ -9,6 +9,8 @@ body:
         **Milestone 5 — Predictive / Alt Track**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
         Indicate which path you took (Path A or Path B) in the notes field.
+        If M4 is still awaiting review, an on-time M5 issue stays open in the prerequisite queue and releases automatically after M4 passes.
+        Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input
     id: builder_name

--- a/.github/ISSUE_TEMPLATE/milestone-m6.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m6.yml
@@ -9,6 +9,8 @@ body:
         **Milestone 6 — Live Deployment**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
         Congratulations on reaching the final milestone!
+        If M5 is still awaiting review, an on-time M6 issue stays open in the prerequisite queue and releases automatically after M5 passes.
+        Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input
     id: builder_name

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+Thank you for contributing to the DEP Engineering Foundations Open Track.
+
+PR title format: type(scope): short present-tense description
+Examples: fix(ci): preserve on-time submissions
+          docs(curriculum): clarify the M2 checklist
+
+Replace the placeholders below and remove guidance that does not apply.
+-->
+
+## Summary
+
+<!-- Explain what this PR changes and why in 2–4 concise bullets. -->
+
+- <!-- Add summary item -->
+
+## Related issues
+
+<!-- Use "Closes #123" only when merging this PR should close that issue. Otherwise use "Related to #123". -->
+
+N/A
+
+## Changes
+
+<!-- List the important behavior, content, workflow, or interface changes. -->
+
+- <!-- Add change item -->
+
+## Test plan
+
+<!-- Include commands run and any manual checks still required. -->
+
+- [ ] Automated checks pass
+- [ ] Relevant behavior was verified manually
+
+## Rollout / follow-up
+
+<!-- Describe migrations, post-merge actions, monitoring, or follow-up work. Write "None" when not applicable. -->
+
+None
+
+## Screenshots
+
+<!-- Required for visible UI changes. Remove this section or write "N/A" when not applicable. -->
+
+N/A
+
+## Checklist
+
+- [ ] The PR is focused and I reviewed my own changes
+- [ ] Tests and manual verification are documented above
+- [ ] Documentation and `CHANGELOG.md` are updated, or are not applicable
+- [ ] No credentials, private notes, personal data, or internal links are exposed
+- [ ] Rollout and compatibility considerations are documented, or are not applicable

--- a/.github/scripts/milestone_policy.py
+++ b/.github/scripts/milestone_policy.py
@@ -1,0 +1,112 @@
+"""Pure policy helpers for milestone tooling and regression tests.
+
+GitHub API mutations stay in the workflows. Keeping parsing and state decisions
+here makes the deadline, identity, and milestone rules independently testable.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from urllib.parse import urlparse
+
+
+MILESTONES = ("M0", "M1", "M2", "M3", "M4", "M5", "M6")
+STATE_LABELS = (
+    "auto-check-pending",
+    "waiting-on-prerequisite",
+    "ready-for-review",
+    "needs-improvement",
+    "passed",
+    "late-submission",
+)
+
+
+def extract_field(body: str, heading: str) -> str:
+    """Extract a value from GitHub issue-form ``### Heading`` output."""
+    match = re.search(
+        rf"###\s+{re.escape(heading)}\s*\n+([^\n#]+)",
+        body or "",
+        flags=re.IGNORECASE,
+    )
+    return match.group(1).strip() if match else ""
+
+
+def normalize_repo_url(value: str) -> str:
+    """Return a lowercase ``owner/repo`` identity for a GitHub repository URL."""
+    raw = (value or "").strip()
+    try:
+        parsed = urlparse(raw)
+    except ValueError:
+        return ""
+
+    if parsed.scheme not in {"http", "https"} or parsed.netloc.lower() != "github.com":
+        return ""
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) < 2:
+        return ""
+
+    owner = parts[0]
+    repo = parts[1]
+    if repo.lower().endswith(".git"):
+        repo = repo[:-4]
+    if not owner or not repo:
+        return ""
+    return f"{owner}/{repo}".lower()
+
+
+def parse_timestamp(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp, including a trailing ``Z``."""
+    normalized = (value or "").strip().replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+def is_on_time(created_at: str, deadline: str) -> bool:
+    return parse_timestamp(created_at) <= parse_timestamp(deadline)
+
+
+def previous_milestone(milestone: str) -> str | None:
+    try:
+        index = MILESTONES.index(milestone.upper())
+    except ValueError:
+        return None
+    return MILESTONES[index - 1] if index > 0 else None
+
+
+def next_milestone(milestone: str) -> str | None:
+    try:
+        index = MILESTONES.index(milestone.upper())
+    except ValueError:
+        return None
+    return MILESTONES[index + 1] if index < len(MILESTONES) - 1 else None
+
+
+def extract_recheck_hash(comment: str) -> str:
+    """Accept ``/recheck <hash>`` and legacy comments containing only a hash."""
+    text = (comment or "").strip()
+    command = re.search(r"(?:^|\s)/recheck\s+([0-9a-f]{40})(?:\s|$)", text, re.I)
+    if command:
+        return command.group(1).lower()
+    if re.fullmatch(r"[0-9a-f]{40}", text, re.I):
+        return text.lower()
+    return ""
+
+
+def decide_state(*, deadline_ok: bool, snapshot_ok: bool, prerequisite_ok: bool) -> str:
+    """Return the single workflow state that should follow evaluation."""
+    if not deadline_ok:
+        return "late-submission"
+    if not snapshot_ok:
+        return "needs-improvement"
+    if not prerequisite_ok:
+        return "waiting-on-prerequisite"
+    return "ready-for-review"
+
+
+def choose_latest_on_time(issues: list[dict], deadline: str) -> dict | None:
+    """Choose the newest issue that still preserves deadline eligibility."""
+    eligible = [issue for issue in issues if is_on_time(issue["created_at"], deadline)]
+    if not eligible:
+        return None
+    return max(eligible, key=lambda issue: (parse_timestamp(issue["created_at"]), issue["number"]))

--- a/.github/scripts/test_milestone_policy.py
+++ b/.github/scripts/test_milestone_policy.py
@@ -1,0 +1,93 @@
+from datetime import timezone
+
+import pytest
+
+from milestone_policy import (
+    MILESTONES,
+    choose_latest_on_time,
+    decide_state,
+    extract_field,
+    extract_recheck_hash,
+    is_on_time,
+    next_milestone,
+    normalize_repo_url,
+    parse_timestamp,
+    previous_milestone,
+)
+
+
+def test_extract_field_from_issue_form_body():
+    body = "### Builder Name\n\nAda\n\n### GitHub Repo URL\n\nhttps://github.com/Ada/Project.git\n"
+    assert extract_field(body, "Builder Name") == "Ada"
+    assert extract_field(body, "GitHub Repo URL") == "https://github.com/Ada/Project.git"
+    assert extract_field(body, "Commit Hash") == ""
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/Ada/Project", "ada/project"),
+        ("https://github.com/Ada/Project.git", "ada/project"),
+        ("https://github.com/Ada/Project/blob/main/README.md", "ada/project"),
+        ("https://gitlab.com/Ada/Project", ""),
+        ("not a url", ""),
+    ],
+)
+def test_normalize_repo_url(url, expected):
+    assert normalize_repo_url(url) == expected
+
+
+def test_deadline_boundary_uses_timezone_offset():
+    deadline = "2026-07-12T23:59:59+08:00"
+    assert is_on_time("2026-07-12T15:59:59Z", deadline)
+    assert not is_on_time("2026-07-12T16:00:00Z", deadline)
+    assert parse_timestamp(deadline).astimezone(timezone.utc).isoformat() == "2026-07-12T15:59:59+00:00"
+
+
+def test_all_milestone_neighbors_are_sequential():
+    assert previous_milestone("M0") is None
+    assert next_milestone("M6") is None
+    for index, milestone in enumerate(MILESTONES[1:], start=1):
+        assert previous_milestone(milestone) == MILESTONES[index - 1]
+    for index, milestone in enumerate(MILESTONES[:-1]):
+        assert next_milestone(milestone) == MILESTONES[index + 1]
+
+
+@pytest.mark.parametrize(
+    ("comment", "expected"),
+    [
+        ("/recheck 0123456789abcdef0123456789abcdef01234567", "0123456789abcdef0123456789abcdef01234567"),
+        ("Please /recheck ABCDEF0123456789ABCDEF0123456789ABCDEF01 now", "abcdef0123456789abcdef0123456789abcdef01"),
+        ("0123456789abcdef0123456789abcdef01234567", "0123456789abcdef0123456789abcdef01234567"),
+        ("commit 0123456789abcdef0123456789abcdef01234567", ""),
+    ],
+)
+def test_extract_recheck_hash(comment, expected):
+    assert extract_recheck_hash(comment) == expected
+
+
+@pytest.mark.parametrize(
+    ("deadline_ok", "snapshot_ok", "prerequisite_ok", "expected"),
+    [
+        (False, True, True, "late-submission"),
+        (True, False, True, "needs-improvement"),
+        (True, True, False, "waiting-on-prerequisite"),
+        (True, True, True, "ready-for-review"),
+    ],
+)
+def test_decide_state(deadline_ok, snapshot_ok, prerequisite_ok, expected):
+    assert decide_state(
+        deadline_ok=deadline_ok,
+        snapshot_ok=snapshot_ok,
+        prerequisite_ok=prerequisite_ok,
+    ) == expected
+
+
+def test_choose_latest_on_time_ignores_late_replacement():
+    deadline = "2026-07-12T23:59:59+08:00"
+    issues = [
+        {"number": 1, "created_at": "2026-07-12T12:00:00Z"},
+        {"number": 2, "created_at": "2026-07-12T15:00:00Z"},
+        {"number": 3, "created_at": "2026-07-12T16:00:00Z"},
+    ]
+    assert choose_latest_on_time(issues, deadline)["number"] == 2

--- a/.github/workflows/_milestone-evaluate.yml
+++ b/.github/workflows/_milestone-evaluate.yml
@@ -1,0 +1,481 @@
+name: Reusable Milestone Evaluation
+
+on:
+  workflow_call:
+    inputs:
+      issue_number:
+        required: true
+        type: number
+      commit_hash:
+        required: false
+        type: string
+        default: ""
+      check_duplicate:
+        required: false
+        type: boolean
+        default: false
+      override_deadline:
+        required: false
+        type: boolean
+        default: false
+      audit_reason:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      DISCORD_WEBHOOK_URL:
+        required: false
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    concurrency:
+      group: milestone-${{ inputs.issue_number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out curriculum repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Load issue and enforce submission eligibility
+        id: submission
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          INPUT_COMMIT_HASH: ${{ inputs.commit_hash }}
+          CHECK_DUPLICATE: ${{ inputs.check_duplicate }}
+          OVERRIDE_DEADLINE: ${{ inputs.override_deadline }}
+          AUDIT_REASON: ${{ inputs.audit_reason }}
+        with:
+          script: |
+            const fs = require('fs');
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const overrideDeadline = process.env.OVERRIDE_DEADLINE === 'true';
+            const auditReason = (process.env.AUDIT_REASON || '').trim();
+            const stateLabels = [
+              'auto-check-pending',
+              'waiting-on-prerequisite',
+              'ready-for-review',
+              'needs-improvement',
+              'passed',
+              'late-submission'
+            ];
+            const labelDefinitions = {
+              'waiting-on-prerequisite': {
+                color: 'FBCA04',
+                description: 'On-time submission waiting for the previous milestone to pass'
+              },
+              'ready-for-review': {
+                color: '1D76DB',
+                description: 'Automated checks and prerequisite gate passed; reviewer action needed'
+              },
+              'late-submission': {
+                color: 'B60205',
+                description: 'First submission was created after the milestone deadline'
+              }
+            };
+
+            for (const [name, definition] of Object.entries(labelDefinitions)) {
+              try {
+                await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name,
+                  ...definition
+                });
+              }
+            }
+
+            const issue = (await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            })).data;
+            const labelNames = issue.labels.map(label => typeof label === 'string' ? label : label.name);
+            const milestone = labelNames.find(label => /^M[0-6]$/.test(label));
+            if (!labelNames.includes('milestone-submission') || !milestone) {
+              core.setFailed(`Issue #${issueNumber} is not a valid milestone submission.`);
+              return;
+            }
+            if (labelNames.includes('passed')) {
+              core.setOutput('stop', 'true');
+              core.notice(`Issue #${issueNumber} is already passed; evaluation skipped.`);
+              return;
+            }
+            if (overrideDeadline && !auditReason) {
+              core.setFailed('An audit reason is required when overriding a deadline.');
+              return;
+            }
+
+            const body = issue.body || '';
+            const extract = heading => {
+              const match = body.match(new RegExp(`###\\s+${heading}\\s*\\n+([^\\n#]+)`, 'i'));
+              return match ? match[1].trim() : '';
+            };
+            const rawRepoUrl = extract('GitHub Repo URL');
+            const repoMatch = rawRepoUrl.match(/^https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:\/|$)/i);
+            const repoUrl = repoMatch ? `https://github.com/${repoMatch[1]}/${repoMatch[2]}` : '';
+
+            let commitHash = (process.env.INPUT_COMMIT_HASH || '').trim().toLowerCase();
+            if (!commitHash) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100
+              });
+              for (const comment of comments) {
+                const authorized = comment.user.login.toLowerCase() === issue.user.login.toLowerCase() ||
+                  ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(comment.author_association);
+                if (!authorized) continue;
+                const text = (comment.body || '').trim();
+                const command = text.match(/(?:^|\s)\/recheck\s+([0-9a-f]{40})(?:\s|$)/i);
+                const legacy = text.match(/^[0-9a-f]{40}$/i);
+                const match = command || legacy;
+                if (match) commitHash = (command ? command[1] : legacy[0]).toLowerCase();
+              }
+            }
+            if (!commitHash) commitHash = extract('Commit Hash').toLowerCase();
+
+            const transition = async (target, close = false) => {
+              for (const label of stateLabels) {
+                if (label === target || !labelNames.includes(label)) continue;
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    name: label
+                  });
+                } catch (_) {}
+              }
+              if (target && !labelNames.includes(target)) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: [target]
+                });
+              }
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                state: close ? 'closed' : 'open',
+                ...(close ? { state_reason: 'not_planned' } : {})
+              });
+            };
+
+            if (process.env.CHECK_DUPLICATE === 'true') {
+              const candidates = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: `milestone-submission,${milestone}`,
+                state: 'all',
+                per_page: 100
+              });
+              const earlier = candidates
+                .filter(candidate => candidate.number !== issueNumber)
+                .filter(candidate => candidate.user.login.toLowerCase() === issue.user.login.toLowerCase())
+                .filter(candidate => new Date(candidate.created_at) <= new Date(issue.created_at))
+                .filter(candidate => !candidate.labels.some(label => label.name === 'duplicate'))
+                .sort((a, b) => new Date(a.created_at) - new Date(b.created_at))[0];
+              if (earlier) {
+                const marker = `<!-- dep-duplicate:${earlier.number} -->`;
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  per_page: 100
+                });
+                if (!comments.some(comment => (comment.body || '').includes(marker))) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    body: `${marker}\n## Duplicate milestone submission\n\nContinue on #${earlier.number}. Post \`/recheck <40-character-hash>\` there if you need to submit a revised snapshot. Do not open another issue.\n\n---\n_DEP submission bot_`
+                  });
+                }
+                await transition(null, true);
+                if (!labelNames.includes('duplicate')) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issueNumber,
+                    labels: ['duplicate']
+                  });
+                }
+                core.setOutput('stop', 'true');
+                return;
+              }
+            }
+
+            const deadlines = JSON.parse(fs.readFileSync('.github/milestone-deadlines.json', 'utf8'));
+            const deadline = deadlines[milestone];
+            const deadlineOk = !deadline || new Date(issue.created_at) <= new Date(deadline) || overrideDeadline;
+            if (!deadlineOk) {
+              const marker = `<!-- dep-eval:${milestone}:late-submission -->`;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100
+              });
+              if (!comments.some(comment => (comment.body || '').includes(marker))) {
+                const deadlinePht = new Date(deadline).toLocaleString('en-PH', {
+                  timeZone: 'Asia/Manila', dateStyle: 'medium', timeStyle: 'medium'
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `${marker}\n## Auto-Check Results — ${milestone}\n\n> ⛔ **Deadline passed.** The ${milestone} deadline was **${deadlinePht} PHT**.\n\nThis is a new issue created after the cutoff. If you had an earlier on-time issue, continue on that issue instead.\n\n---\n_DEP submission bot_`
+                });
+              }
+              await transition('late-submission', true);
+              core.setOutput('stop', 'true');
+              return;
+            }
+
+            core.setOutput('stop', 'false');
+            core.setOutput('milestone', milestone);
+            core.setOutput('repo_url', repoUrl);
+            core.setOutput('commit_hash', commitHash);
+            core.setOutput('issue_author', issue.user.login);
+            core.setOutput('was_ready', labelNames.includes('ready-for-review') ? 'true' : 'false');
+            core.setOutput('deadline_overridden', overrideDeadline ? 'true' : 'false');
+            core.setOutput('audit_reason', auditReason);
+
+      - name: Clone submitted snapshot
+        id: clone
+        if: steps.submission.outputs.stop == 'false'
+        env:
+          REPO_URL: ${{ steps.submission.outputs.repo_url }}
+          COMMIT_HASH: ${{ steps.submission.outputs.commit_hash }}
+        run: |
+          if [[ ! "$COMMIT_HASH" =~ ^[0-9a-fA-F]{40}$ ]] || [ -z "$REPO_URL" ]; then
+            echo "clone_ok=false" >> "$GITHUB_OUTPUT"
+            echo "clone_error=The repository URL or 40-character commit hash is invalid." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! git clone --filter=blob:none --no-checkout "$REPO_URL" builder-repo; then
+            echo "clone_ok=false" >> "$GITHUB_OUTPUT"
+            echo "clone_error=The repository could not be cloned. Confirm it is public." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          cd builder-repo
+          git fetch --depth 1 origin "$COMMIT_HASH" || true
+          if ! git checkout --detach "$COMMIT_HASH"; then
+            echo "clone_ok=false" >> "$GITHUB_OUTPUT"
+            echo "clone_error=The submitted commit was not found in the repository." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "clone_ok=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run milestone structural checks
+        id: checks
+        if: steps.submission.outputs.stop == 'false' && steps.clone.outputs.clone_ok == 'true'
+        continue-on-error: true
+        run: |
+          python .github/scripts/milestone_check.py \
+            --milestone "${{ steps.submission.outputs.milestone }}" \
+            --repo-path builder-repo \
+            --output-file check_result.json
+
+      - name: Check prerequisite by builder identity
+        id: gate
+        if: steps.submission.outputs.stop == 'false'
+        uses: actions/github-script@v7
+        env:
+          MILESTONE: ${{ steps.submission.outputs.milestone }}
+          ISSUE_AUTHOR: ${{ steps.submission.outputs.issue_author }}
+        with:
+          script: |
+            const milestones = ['M0', 'M1', 'M2', 'M3', 'M4', 'M5', 'M6'];
+            const milestone = process.env.MILESTONE;
+            const index = milestones.indexOf(milestone);
+            if (index <= 0) {
+              core.setOutput('gate_ok', 'true');
+              core.setOutput('previous', 'none');
+              return;
+            }
+            const previous = milestones[index - 1];
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: `milestone-submission,${previous},passed`,
+              state: 'all',
+              per_page: 100
+            });
+            const found = issues.some(issue =>
+              issue.user.login.toLowerCase() === process.env.ISSUE_AUTHOR.toLowerCase()
+            );
+            core.setOutput('gate_ok', found ? 'true' : 'false');
+            core.setOutput('previous', previous);
+
+      - name: Apply workflow state and publish result
+        if: always() && steps.submission.outputs.stop == 'false'
+        uses: actions/github-script@v7
+        env:
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          MILESTONE: ${{ steps.submission.outputs.milestone }}
+          COMMIT_HASH: ${{ steps.submission.outputs.commit_hash }}
+          CLONE_OK: ${{ steps.clone.outputs.clone_ok }}
+          CLONE_ERROR: ${{ steps.clone.outputs.clone_error }}
+          GATE_OK: ${{ steps.gate.outputs.gate_ok }}
+          PREVIOUS_MILESTONE: ${{ steps.gate.outputs.previous }}
+          WAS_READY: ${{ steps.submission.outputs.was_ready }}
+          DEADLINE_OVERRIDDEN: ${{ steps.submission.outputs.deadline_overridden }}
+          AUDIT_REASON: ${{ steps.submission.outputs.audit_reason }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        with:
+          script: |
+            const fs = require('fs');
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const issue = (await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            })).data;
+            const currentLabels = issue.labels.map(label => typeof label === 'string' ? label : label.name);
+            if (currentLabels.includes('passed')) {
+              core.notice('A reviewer passed this issue while evaluation was running; preserving the verdict.');
+              return;
+            }
+
+            let results = null;
+            if (process.env.CLONE_OK === 'true' && fs.existsSync('check_result.json')) {
+              results = JSON.parse(fs.readFileSync('check_result.json', 'utf8'));
+            }
+            const snapshotOk = process.env.CLONE_OK === 'true' && results?.all_passed === true;
+            const prerequisiteOk = process.env.GATE_OK === 'true';
+            const target = !snapshotOk
+              ? 'needs-improvement'
+              : prerequisiteOk
+                ? 'ready-for-review'
+                : 'waiting-on-prerequisite';
+            const stateLabels = [
+              'auto-check-pending',
+              'waiting-on-prerequisite',
+              'ready-for-review',
+              'needs-improvement',
+              'late-submission'
+            ];
+            for (const label of stateLabels) {
+              if (label === target || !currentLabels.includes(label)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: label
+                });
+              } catch (_) {}
+            }
+            if (!currentLabels.includes(target)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: [target]
+              });
+            }
+            if (currentLabels.includes('duplicate')) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'duplicate'
+                });
+              } catch (_) {}
+            }
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              state: 'open'
+            });
+
+            let details = '';
+            if (results) {
+              details = results.checks.map(check =>
+                `${check.passed ? '✅' : '❌'} ${check.name}${!check.passed && check.hint ? `\n   _${check.hint}_` : ''}`
+              ).join('\n');
+            } else {
+              details = `❌ ${process.env.CLONE_ERROR || 'The submitted snapshot could not be checked.'}`;
+            }
+            let guidance;
+            if (target === 'needs-improvement') {
+              guidance = '**Action required:** Fix the problems above, push a commit, then comment `/recheck <40-character-hash>` on this issue. Your original on-time submission date remains preserved.';
+            } else if (target === 'waiting-on-prerequisite') {
+              guidance = `**Submission recorded on time.** This issue will remain open until ${process.env.PREVIOUS_MILESTONE} is marked \`passed\`. It will then be checked again and released automatically. Do not open another issue.`;
+            } else {
+              guidance = process.env.MILESTONE === 'M0'
+                ? '**Ready for human review.** The automated structural checks passed; a reviewer must assess the problem statement, audience, and data source before applying `passed`.'
+                : '**Ready for human review.** The automated checks and prerequisite gate passed.';
+            }
+            const marker = `<!-- dep-eval:${process.env.MILESTONE}:${process.env.COMMIT_HASH}:${target} -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              per_page: 100
+            });
+            if (!comments.some(comment => (comment.body || '').includes(marker))) {
+              const overrideNote = process.env.DEADLINE_OVERRIDDEN === 'true'
+                ? `\n\n> Deadline override recorded: ${process.env.AUDIT_REASON}`
+                : '';
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `${marker}\n## Evaluation Results — ${process.env.MILESTONE}\n\n${details}\n\n${guidance}${overrideNote}\n\n---\n_DEP submission bot_`
+              });
+            }
+
+            const becameReady = target === 'ready-for-review' && process.env.WAS_READY !== 'true';
+            if (becameReady && process.env.DISCORD_WEBHOOK_URL) {
+              try {
+                const enrolledResponse = await fetch(`https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/main/.github/enrolled-participants.json`);
+                const enrolledData = await enrolledResponse.json();
+                const enrolled = new Set((enrolledData.participants || []).map(login => login.toLowerCase()));
+                if (enrolled.has(issue.user.login.toLowerCase())) {
+                  const body = issue.body || '';
+                  const extract = heading => body.match(new RegExp(`###\\s+${heading}\\s*\\n+([^\\n#]+)`, 'i'))?.[1]?.trim() || '—';
+                  await fetch(process.env.DISCORD_WEBHOOK_URL, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ embeds: [{
+                      title: `📬 Submission Ready for Review — ${process.env.MILESTONE}`,
+                      color: 0x1D76DB,
+                      fields: [
+                        { name: 'Builder', value: extract('Builder Name'), inline: true },
+                        { name: 'Cohort', value: extract('Cohort'), inline: true },
+                        { name: 'Milestone', value: process.env.MILESTONE, inline: true },
+                        { name: 'Commit', value: `\`${process.env.COMMIT_HASH.slice(0, 7)}\``, inline: true },
+                        { name: 'Issue', value: issue.html_url, inline: false }
+                      ],
+                      footer: { text: 'Automated checks and prerequisite gate passed' },
+                      timestamp: new Date().toISOString()
+                    }] })
+                  });
+                }
+              } catch (error) {
+                core.warning(`Discord notification failed: ${error.message}`);
+              }
+            }
+            core.summary.addHeading(`Milestone ${process.env.MILESTONE} evaluation`)
+              .addRaw(`Issue #${issueNumber} → ${target}`)
+              .write();

--- a/.github/workflows/milestone-check.yml
+++ b/.github/workflows/milestone-check.yml
@@ -1,385 +1,51 @@
-name: Milestone Auto-Check
+name: Milestone Submission Evaluation
 
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Milestone issue number to evaluate
+        required: true
+        type: number
+      commit_hash:
+        description: Optional 40-character commit hash override
+        required: false
+        type: string
+      override_deadline:
+        description: Allow a late issue through the deadline gate
+        required: true
+        type: boolean
+        default: false
+      audit_reason:
+        description: Required explanation when overriding the deadline
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
 
 jobs:
-  auto-check:
-    if: contains(github.event.issue.labels.*.name, 'auto-check-pending')
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
+  evaluate-opened-issue:
+    if: >-
+      github.event_name == 'issues' &&
+      contains(github.event.issue.labels.*.name, 'milestone-submission') &&
+      contains(github.event.issue.labels.*.name, 'auto-check-pending')
+    uses: ./.github/workflows/_milestone-evaluate.yml
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      check_duplicate: true
+    secrets: inherit
 
-    steps:
-      - name: Check out curriculum repo
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Parse issue body
-        id: parse
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = context.payload.issue.body || '';
-            const labels = context.payload.issue.labels.map(l => l.name);
-
-            const milestone = labels.find(l => /^M\d$/.test(l)) || 'unknown';
-
-            // Extract fields from GitHub issue form body (### Heading\n\nValue format)
-            const extract = (heading) => {
-              const re = new RegExp(`###\\s+${heading}\\s*\\n+([^\\n#]+)`, 'i');
-              const m = body.match(re);
-              return m ? m[1].trim() : '';
-            };
-
-            const repoUrl   = extract('GitHub Repo URL');
-            const commitHash = extract('Commit Hash');
-
-            core.setOutput('milestone', milestone);
-            core.setOutput('repo_url', repoUrl);
-            core.setOutput('commit_hash', commitHash);
-
-      - name: Check milestone deadline
-        id: deadline
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const milestone  = '${{ steps.parse.outputs.milestone }}';
-            const createdStr = context.payload.issue.created_at;
-
-            let deadlines;
-            try {
-              deadlines = JSON.parse(fs.readFileSync('.github/milestone-deadlines.json', 'utf8'));
-            } catch (_) {
-              core.setOutput('deadline_ok', 'true');
-              return;
-            }
-
-            const deadlineStr = deadlines[milestone];
-            if (!deadlineStr) {
-              core.setOutput('deadline_ok', 'true');
-              return;
-            }
-
-            const created  = new Date(createdStr);
-            const deadline = new Date(deadlineStr);
-
-            if (created <= deadline) {
-              core.setOutput('deadline_ok', 'true');
-              return;
-            }
-
-            core.setOutput('deadline_ok', 'false');
-
-            const fmt = (d) => d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
-            const deadlineFmt = (d) => {
-              const s = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
-              return s.replace(' 23:59:59 UTC', ' 23:59:59 UTC (end of day)');
-            };
-
-            const body = [
-              `## Auto-Check Results — ${milestone}`,
-              '',
-              `> ⛔ **Deadline passed.** Submissions for ${milestone} closed on **${deadlineFmt(deadline)}**.`,
-              '',
-              `This issue was created on **${fmt(created)}**, which is past the deadline.`,
-              '',
-              `**What to do:**`,
-              `If you have a legitimate reason for the late submission, reach out to the organizing team.`,
-              ``,
-              `---`,
-              `_Auto-Check by DEP submission bot_`
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body
-            });
-
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                name: 'auto-check-pending'
-              });
-            } catch (_) {}
-
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              state: 'closed',
-              state_reason: 'not_planned'
-            });
-
-      - name: Check prerequisite milestone
-        id: gate
-        if: steps.deadline.outputs.deadline_ok == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const MILESTONES = ['M0', 'M1', 'M2', 'M3', 'M4', 'M5', 'M6'];
-            const milestone = '${{ steps.parse.outputs.milestone }}';
-            const repoUrl   = '${{ steps.parse.outputs.repo_url }}';
-            const idx = MILESTONES.indexOf(milestone);
-
-            // M0 has no prerequisite
-            if (idx <= 0) {
-              core.setOutput('gate_ok', 'true');
-              return;
-            }
-
-            const prevMilestone = MILESTONES[idx - 1];
-            core.setOutput('prev_milestone', prevMilestone);
-
-            // Normalise repo URL to base owner/repo (handles blob/tree/file URLs)
-            const urlMatch = repoUrl.match(/(https?:\/\/github\.com\/[\w.-]+\/[\w.-]+?)(?:\.git)?(?:\/|$)/);
-            const baseUrl = urlMatch ? urlMatch[1] : null;
-
-            if (!baseUrl) {
-              core.setOutput('gate_ok', 'false');
-              return;
-            }
-
-            // Find all passed issues for the previous milestone
-            const issues = await github.paginate(github.rest.issues.listForRepo, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: `milestone-submission,${prevMilestone},passed`,
-              state: 'all'
-            });
-
-            const found = issues.some(issue => issue.body && issue.body.includes(baseUrl));
-            core.setOutput('gate_ok', found ? 'true' : 'false');
-
-      - name: Block if prerequisite not met
-        if: steps.gate.outputs.gate_ok == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const milestone     = '${{ steps.parse.outputs.milestone }}';
-            const prevMilestone = '${{ steps.gate.outputs.prev_milestone }}';
-
-            const body = [
-              `## Auto-Check Results — ${milestone}`,
-              '',
-              `> ⛔ **Gate blocked.** Your ${prevMilestone} submission has not been marked \`passed\` yet.`,
-              '',
-              `You must complete and pass **${prevMilestone}** before submitting **${milestone}**. This is a program requirement — milestones must be completed in order.`,
-              '',
-              `**What to do:**`,
-              `1. Check your ${prevMilestone} submission issue to see if it has a \`passed\` label`,
-              `2. If it shows \`needs-improvement\`, address the reviewer's comment and resubmit`,
-              `3. If you haven't submitted ${prevMilestone} yet, do that first`,
-              `4. Once ${prevMilestone} is marked \`passed\`, close this issue and open a new ${milestone} submission`,
-              '',
-              `---`,
-              `_Auto-Check by DEP submission bot_`
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body
-            });
-
-            // Remove auto-check-pending and close the issue
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                name: 'auto-check-pending'
-              });
-            } catch (_) {}
-
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              state: 'closed',
-              state_reason: 'not_planned'
-            });
-
-      - name: Clone builder repo at commit
-        id: clone
-        if: steps.deadline.outputs.deadline_ok == 'true' && steps.gate.outputs.gate_ok == 'true'
-        run: |
-          REPO="${{ steps.parse.outputs.repo_url }}"
-          HASH="${{ steps.parse.outputs.commit_hash }}"
-
-          if [ -z "$REPO" ] || [ -z "$HASH" ]; then
-            echo "clone_ok=false" >> $GITHUB_OUTPUT
-            echo "clone_error=Could not parse repo URL or commit hash from issue body." >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          git clone --depth 1 "$REPO" builder-repo 2>&1 || {
-            echo "clone_ok=false" >> $GITHUB_OUTPUT
-            echo "clone_error=Failed to clone $REPO. Is the repo public?" >> $GITHUB_OUTPUT
-            exit 0
-          }
-
-          cd builder-repo
-          git fetch --depth 1 origin "$HASH" 2>&1 || true
-          git checkout "$HASH" 2>&1 || {
-            echo "clone_ok=false" >> $GITHUB_OUTPUT
-            echo "clone_error=Commit $HASH not found in $REPO." >> $GITHUB_OUTPUT
-            exit 0
-          }
-
-          echo "clone_ok=true" >> $GITHUB_OUTPUT
-
-      - name: Run milestone checks
-        id: checks
-        if: steps.deadline.outputs.deadline_ok == 'true' && steps.gate.outputs.gate_ok == 'true' && steps.clone.outputs.clone_ok == 'true'
-        run: |
-          python .github/scripts/milestone_check.py \
-            --milestone "${{ steps.parse.outputs.milestone }}" \
-            --repo-path builder-repo \
-            --output-file check_result.json
-
-      - name: Post auto-check comment
-        if: steps.deadline.outputs.deadline_ok == 'true' && steps.gate.outputs.gate_ok == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const milestone = '${{ steps.parse.outputs.milestone }}';
-            const cloneOk   = '${{ steps.clone.outputs.clone_ok }}';
-            const cloneErr  = '${{ steps.clone.outputs.clone_error }}';
-
-            let body = `## Auto-Check Results — ${milestone}\n\n`;
-
-            if (cloneOk !== 'true') {
-              body += `> **Error:** ${cloneErr || 'Unknown clone failure.'}\n\n`;
-              body += `Please verify your repo URL and commit hash, then open a new ${milestone} submission with the correct details. This issue will now be closed automatically.\n`;
-            } else {
-              let results;
-              try {
-                results = JSON.parse(fs.readFileSync('check_result.json', 'utf8'));
-              } catch (e) {
-                body += `> **Error:** Could not parse check results. Please contact a moderator.\n`;
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.issue.number,
-                  body
-                });
-                return;
-              }
-
-              const pass = results.checks.filter(c => c.passed);
-              const fail = results.checks.filter(c => !c.passed);
-
-              for (const c of results.checks) {
-                body += `${c.passed ? '✅' : '❌'} ${c.name}\n`;
-                if (!c.passed && c.hint) body += `   _${c.hint}_\n`;
-              }
-
-              body += `\n`;
-
-              if (fail.length === 0) {
-                body += `**All structural checks passed.** A Milestone Reviewer will evaluate your submission shortly.\n`;
-              } else {
-                body += `**${fail.length} check(s) failed.** Fix the issues above, push a new commit, then post the new commit hash as a comment on this issue to resubmit.\n`;
-              }
-            }
-
-            body += `\n---\n_Auto-Check by DEP submission bot_`;
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body
-            });
-
-            // Remove auto-check-pending label
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                name: 'auto-check-pending'
-              });
-            } catch (_) {}
-
-            // Auto-close on clone failure — data is bad, fix and resubmit fresh
-            if (cloneOk !== 'true') {
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.issue.number,
-                state: 'closed',
-                state_reason: 'not_planned'
-              });
-              return;
-            }
-
-            // Notify Discord if all checks passed
-            const allPassed = cloneOk === 'true' && (() => {
-              try {
-                const r = JSON.parse(fs.readFileSync('check_result.json', 'utf8'));
-                return r.all_passed;
-              } catch (_) { return false; }
-            })();
-
-            if (allPassed) {
-              const issueUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${context.payload.issue.number}`;
-              const milestone  = '${{ steps.parse.outputs.milestone }}';
-              const builderName = (context.payload.issue.body || '').match(/###\s+Builder Name\s*\n+([^\n#]+)/i)?.[1]?.trim() || context.payload.issue.user.login;
-              const cohort      = (context.payload.issue.body || '').match(/###\s+Cohort\s*\n+([^\n#]+)/i)?.[1]?.trim() || '—';
-              const repoUrl     = '${{ steps.parse.outputs.repo_url }}';
-
-              // Auto-apply passed label for M0 (purely structural checks — no subjective review needed)
-              if (milestone === 'M0') {
-                try {
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.payload.issue.number,
-                    labels: ['passed']
-                  });
-                } catch (_) {}
-              }
-
-              // Only notify Discord for enrolled participants
-              const enrolledRes = await fetch(`https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/main/.github/enrolled-participants.json`);
-              const enrolledData = await enrolledRes.json();
-              const enrolledSet = new Set((enrolledData.participants || []).map(u => u.toLowerCase()));
-              const isEnrolled = enrolledSet.has(context.payload.issue.user.login.toLowerCase());
-              if (!isEnrolled) return;
-
-              const discordBody = {
-                embeds: [{
-                  title: `📬 New Submission Ready for Review — ${milestone}`,
-                  color: 0x0052CC,
-                  fields: [
-                    { name: 'Builder', value: builderName, inline: true },
-                    { name: 'Cohort',  value: cohort,       inline: true },
-                    { name: 'Milestone', value: milestone,  inline: true },
-                    { name: 'Repo',    value: repoUrl,      inline: false },
-                    { name: 'Issue',   value: issueUrl,     inline: false },
-                  ],
-                  footer: { text: 'All structural checks passed ✅ — reviewer action needed within 5 days' },
-                  timestamp: new Date().toISOString()
-                }]
-              };
-
-              await fetch('${{ secrets.DISCORD_WEBHOOK_URL }}', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(discordBody)
-              });
-            }
+  evaluate-manual-request:
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/_milestone-evaluate.yml
+    with:
+      issue_number: ${{ inputs.issue_number }}
+      commit_hash: ${{ inputs.commit_hash }}
+      check_duplicate: false
+      override_deadline: ${{ inputs.override_deadline }}
+      audit_reason: ${{ inputs.audit_reason }}
+    secrets: inherit

--- a/.github/workflows/milestone-recheck.yml
+++ b/.github/workflows/milestone-recheck.yml
@@ -1,265 +1,50 @@
-name: Milestone Recheck (Resubmission)
+name: Milestone Recheck
 
 on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
-  recheck:
-    if: |
+  parse-recheck:
+    if: >-
       github.event.issue.pull_request == null &&
       contains(github.event.issue.labels.*.name, 'milestone-submission') &&
       contains(github.event.issue.labels.*.name, 'needs-improvement')
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-
+    outputs:
+      authorized: ${{ steps.parse.outputs.authorized }}
+      commit_hash: ${{ steps.parse.outputs.commit_hash }}
     steps:
-      - name: Check out curriculum repo
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Parse resubmission comment
+      - name: Parse and authorize recheck command
         id: parse
         uses: actions/github-script@v7
         with:
           script: |
-            const comment = context.payload.comment.body || '';
-            const issueBody = context.payload.issue.body || '';
-            const labels = context.payload.issue.labels.map(l => l.name);
-
-            // Extract 40-char commit hash from the comment
-            const hashMatch = comment.match(/\b([0-9a-f]{40})\b/i);
-            if (!hashMatch) {
-              core.setOutput('has_hash', 'false');
-              return;
-            }
-            core.setOutput('has_hash', 'true');
-            core.setOutput('commit_hash', hashMatch[1]);
-
-            // Extract milestone from issue labels
-            const milestone = labels.find(l => /^M\d$/.test(l)) || 'unknown';
-            core.setOutput('milestone', milestone);
-
-            // Extract repo URL from original issue body
-            const repoMatch = issueBody.match(/###\s+GitHub Repo URL\s*\n+([^\n#]+)/i);
-            const rawUrl = repoMatch ? repoMatch[1].trim() : '';
-
-            // Normalise to base repo URL (handles blob/tree/file URLs)
-            const urlMatch = rawUrl.match(/(https?:\/\/github\.com\/[\w.-]+\/[\w.-]+?)(?:\.git)?(?:\/|$)/);
-            const repoUrl = urlMatch ? urlMatch[1] : rawUrl;
-            core.setOutput('repo_url', repoUrl);
-
-      - name: Check milestone deadline (original issue)
-        id: deadline
-        if: steps.parse.outputs.has_hash == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const milestone  = '${{ steps.parse.outputs.milestone }}';
-            const createdStr = context.payload.issue.created_at;
-
-            let deadlines;
-            try {
-              deadlines = JSON.parse(fs.readFileSync('.github/milestone-deadlines.json', 'utf8'));
-            } catch (_) {
-              core.setOutput('deadline_ok', 'true');
-              return;
+            const comment = (context.payload.comment.body || '').trim();
+            const command = comment.match(/(?:^|\s)\/recheck\s+([0-9a-f]{40})(?:\s|$)/i);
+            const legacy = comment.match(/^[0-9a-f]{40}$/i);
+            const hash = command ? command[1] : legacy ? legacy[0] : '';
+            const issueAuthor = context.payload.issue.user.login.toLowerCase();
+            const commentAuthor = context.payload.comment.user.login.toLowerCase();
+            const association = context.payload.comment.author_association;
+            const authorized = commentAuthor === issueAuthor ||
+              ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(association);
+            core.setOutput('authorized', authorized && hash ? 'true' : 'false');
+            core.setOutput('commit_hash', hash.toLowerCase());
+            if (hash && !authorized) {
+              core.warning('Ignoring a recheck hash from an unauthorized commenter.');
             }
 
-            const deadlineStr = deadlines[milestone];
-            if (!deadlineStr) {
-              core.setOutput('deadline_ok', 'true');
-              return;
-            }
-
-            const created  = new Date(createdStr);
-            const deadline = new Date(deadlineStr);
-
-            if (created <= deadline) {
-              core.setOutput('deadline_ok', 'true');
-              return;
-            }
-
-            core.setOutput('deadline_ok', 'false');
-
-            const fmt = (d) => d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
-            const deadlineFmt = (d) => {
-              const s = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, ' UTC');
-              return s.replace(' 23:59:59 UTC', ' 23:59:59 UTC (end of day)');
-            };
-
-            const body = [
-              `## Recheck Results — ${milestone}`,
-              '',
-              `> ⛔ **Deadline passed.** Submissions for ${milestone} closed on **${deadlineFmt(deadline)}**.`,
-              '',
-              `The original issue was created on **${fmt(created)}**, which is past the deadline. Resubmissions are not accepted.`,
-              '',
-              `If you have a legitimate reason, reach out to the organizing team.`,
-              ``,
-              `---`,
-              `_Auto-Check by DEP submission bot_`
-            ].join('\n');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body
-            });
-
-      - name: Skip if no commit hash in comment
-        if: steps.parse.outputs.has_hash == 'false'
-        run: echo "Comment does not contain a commit hash — skipping recheck."
-
-      - name: Clone builder repo at new commit
-        id: clone
-        if: steps.deadline.outputs.deadline_ok == 'true' && steps.parse.outputs.has_hash == 'true'
-        run: |
-          REPO="${{ steps.parse.outputs.repo_url }}"
-          HASH="${{ steps.parse.outputs.commit_hash }}"
-
-          if [ -z "$REPO" ] || [ -z "$HASH" ]; then
-            echo "clone_ok=false" >> $GITHUB_OUTPUT
-            echo "clone_error=Could not parse repo URL from original issue body." >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          git clone --depth 1 "$REPO" builder-repo 2>&1 || {
-            echo "clone_ok=false" >> $GITHUB_OUTPUT
-            echo "clone_error=Failed to clone $REPO. Is the repo still public?" >> $GITHUB_OUTPUT
-            exit 0
-          }
-
-          cd builder-repo
-          git fetch --depth 1 origin "$HASH" 2>&1 || true
-          git checkout "$HASH" 2>&1 || {
-            echo "clone_ok=false" >> $GITHUB_OUTPUT
-            echo "clone_error=Commit $HASH not found in $REPO." >> $GITHUB_OUTPUT
-            exit 0
-          }
-
-          echo "clone_ok=true" >> $GITHUB_OUTPUT
-
-      - name: Run milestone checks
-        id: checks
-        if: steps.deadline.outputs.deadline_ok == 'true' && steps.parse.outputs.has_hash == 'true' && steps.clone.outputs.clone_ok == 'true'
-        run: |
-          python .github/scripts/milestone_check.py \
-            --milestone "${{ steps.parse.outputs.milestone }}" \
-            --repo-path builder-repo \
-            --output-file check_result.json
-
-      - name: Post recheck comment
-        if: steps.deadline.outputs.deadline_ok == 'true' && steps.parse.outputs.has_hash == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const milestone  = '${{ steps.parse.outputs.milestone }}';
-            const commitHash = '${{ steps.parse.outputs.commit_hash }}';
-            const cloneOk    = '${{ steps.clone.outputs.clone_ok }}';
-            const cloneErr   = '${{ steps.clone.outputs.clone_error }}';
-
-            let body = `## Recheck Results — ${milestone} (commit \`${commitHash.slice(0,7)}\`)\n\n`;
-
-            if (cloneOk !== 'true') {
-              body += `> **Error:** ${cloneErr || 'Unknown clone failure.'}\n\n`;
-              body += `Fix the issue above and post a new commit hash to resubmit.\n`;
-            } else {
-              let results;
-              try {
-                results = JSON.parse(fs.readFileSync('check_result.json', 'utf8'));
-              } catch (e) {
-                body += `> **Error:** Could not parse check results. Please contact a moderator.\n`;
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.issue.number,
-                  body
-                });
-                return;
-              }
-
-              for (const c of results.checks) {
-                body += `${c.passed ? '✅' : '❌'} ${c.name}\n`;
-                if (!c.passed && c.hint) body += `   _${c.hint}_\n`;
-              }
-
-              body += `\n`;
-              const allPassed = results.all_passed;
-
-              if (allPassed) {
-                body += `**All structural checks passed.** A Milestone Reviewer will re-evaluate your submission.\n`;
-
-                // Remove needs-improvement label
-                try {
-                  await github.rest.issues.removeLabel({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: context.payload.issue.number,
-                    name: 'needs-improvement'
-                  });
-                } catch (_) {}
-
-                // Add auto-check-pending to signal reviewer
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.payload.issue.number,
-                  labels: ['auto-check-pending']
-                });
-
-                // Notify Discord — resubmission passed (enrolled participants only)
-                const enrolledRes = await fetch(`https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/main/.github/enrolled-participants.json`);
-                const enrolledData = await enrolledRes.json();
-                const enrolledSet = new Set((enrolledData.participants || []).map(u => u.toLowerCase()));
-                if (enrolledSet.has(context.payload.issue.user.login.toLowerCase())) {
-                  const issueUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/${context.payload.issue.number}`;
-                  const builderName = (context.payload.issue.body || '').match(/###\s+Builder Name\s*\n+([^\n#]+)/i)?.[1]?.trim() || context.payload.issue.user.login;
-                  const cohort      = (context.payload.issue.body || '').match(/###\s+Cohort\s*\n+([^\n#]+)/i)?.[1]?.trim() || '—';
-                  const repoUrl     = '${{ steps.parse.outputs.repo_url }}';
-
-                  const discordBody = {
-                    embeds: [{
-                      title: `🔄 Resubmission Ready for Review — ${milestone}`,
-                      color: 0xF59E0B,
-                      fields: [
-                        { name: 'Builder',   value: builderName,                       inline: true },
-                        { name: 'Cohort',    value: cohort,                            inline: true },
-                        { name: 'Milestone', value: milestone,                         inline: true },
-                        { name: 'Commit',    value: '`' + commitHash.slice(0,7) + '`', inline: true },
-                        { name: 'Repo',      value: repoUrl,                           inline: false },
-                        { name: 'Issue',     value: issueUrl,                          inline: false },
-                      ],
-                      footer: { text: 'Resubmission passed all checks ✅ — reviewer re-evaluation needed' },
-                      timestamp: new Date().toISOString()
-                    }]
-                  };
-
-                  await fetch('${{ secrets.DISCORD_WEBHOOK_URL }}', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(discordBody)
-                  });
-                }
-
-              } else {
-                body += `**${results.total - results.passed} check(s) still failing.** Fix the issues above and post a new commit hash to resubmit.\n`;
-              }
-            }
-
-            body += `\n---\n_Auto-Recheck by DEP submission bot_`;
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              body
-            });
+  evaluate-recheck:
+    needs: parse-recheck
+    if: needs.parse-recheck.outputs.authorized == 'true'
+    uses: ./.github/workflows/_milestone-evaluate.yml
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      commit_hash: ${{ needs.parse-recheck.outputs.commit_hash }}
+      check_duplicate: false
+    secrets: inherit

--- a/.github/workflows/milestone-repair.yml
+++ b/.github/workflows/milestone-repair.yml
@@ -1,0 +1,213 @@
+name: Repair Gate-Blocked Milestone Submissions
+
+on:
+  workflow_dispatch:
+    inputs:
+      milestone:
+        description: Milestone whose historical gate closures should be consolidated
+        required: true
+        type: choice
+        default: M1
+        options: [M1, M2, M3, M4, M5, M6]
+      dry_run:
+        description: Report proposed changes without mutating issues
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  discover-and-consolidate:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.repair.outputs.matrix }}
+      has_repairs: ${{ steps.repair.outputs.has_repairs }}
+    steps:
+      - name: Check out curriculum repo
+        uses: actions/checkout@v4
+
+      - name: Discover canonical on-time issues
+        id: repair
+        uses: actions/github-script@v7
+        env:
+          TARGET_MILESTONE: ${{ inputs.milestone }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        with:
+          script: |
+            const fs = require('fs');
+            const milestone = process.env.TARGET_MILESTONE;
+            const dryRun = process.env.DRY_RUN === 'true';
+            const deadlines = JSON.parse(fs.readFileSync('.github/milestone-deadlines.json', 'utf8'));
+            const deadline = new Date(deadlines[milestone]);
+            const excludedIssues = new Set([60]);
+            const issues = (await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: `milestone-submission,${milestone}`,
+              state: 'all',
+              per_page: 100
+            })).filter(issue => !excludedIssues.has(issue.number));
+
+            const classifications = new Map();
+            for (const issue of issues) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+              const text = comments.map(comment => comment.body || '').join('\n');
+              classifications.set(issue.number, {
+                gateBlocked: text.includes('Gate blocked'),
+                deadlineRejected: text.includes('Deadline passed')
+              });
+            }
+
+            const groups = new Map();
+            for (const issue of issues) {
+              const classification = classifications.get(issue.number);
+              if (!classification.gateBlocked) continue;
+              if (new Date(issue.created_at) > deadline) continue;
+              const login = issue.user.login.toLowerCase();
+              if (!groups.has(login)) groups.set(login, []);
+              groups.get(login).push(issue);
+            }
+
+            const canonicalIssues = [];
+            const report = [];
+            for (const [login, candidates] of groups.entries()) {
+              const completed = issues
+                .filter(issue => issue.user.login.toLowerCase() === login)
+                .filter(issue => issue.labels.some(label => label.name === 'passed'))
+                .filter(issue => !issue.labels.some(label => label.name === 'duplicate'))
+                .sort((a, b) => {
+                  const byDate = new Date(a.created_at) - new Date(b.created_at);
+                  return byDate || a.number - b.number;
+                });
+              const alreadyPassed = completed.length > 0;
+              const canonical = alreadyPassed ? completed[0] : candidates.sort((a, b) => {
+                const byDate = new Date(b.created_at) - new Date(a.created_at);
+                return byDate || b.number - a.number;
+              })[0];
+              const related = issues.filter(issue => {
+                if (issue.number === canonical.number) return false;
+                if (issue.user.login.toLowerCase() !== login) return false;
+                if (issue.labels.some(label => label.name === 'passed')) return false;
+                const classification = classifications.get(issue.number);
+                return classification.gateBlocked || classification.deadlineRejected;
+              });
+              report.push(`@${canonical.user.login}: canonical #${canonical.number}${alreadyPassed ? ' (already passed; preserved)' : ''}; duplicates ${related.map(issue => `#${issue.number}`).join(', ') || 'none'}`);
+              if (dryRun) continue;
+
+              if (!alreadyPassed) {
+                canonicalIssues.push({ issue_number: canonical.number });
+                const canonicalLabels = canonical.labels.map(label => label.name);
+                for (const label of ['duplicate', 'late-submission', 'waiting-on-prerequisite', 'ready-for-review', 'needs-improvement']) {
+                  if (!canonicalLabels.includes(label)) continue;
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: canonical.number,
+                      name: label
+                    });
+                  } catch (_) {}
+                }
+                if (!canonicalLabels.includes('auto-check-pending')) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: canonical.number,
+                    labels: ['auto-check-pending']
+                  });
+                }
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: canonical.number,
+                  state: 'open'
+                });
+                const canonicalMarker = `<!-- dep-repair-canonical:${canonical.number} -->`;
+                const canonicalComments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: canonical.number,
+                  per_page: 100
+                });
+                if (!canonicalComments.some(comment => (comment.body || '').includes(canonicalMarker))) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: canonical.number,
+                    body: `${canonicalMarker}\n## Submission eligibility restored\n\nThis is now the canonical on-time ${milestone} issue. It will be reevaluated without losing its original submission timestamp.\n\n---\n_DEP submission repair_`
+                  });
+                }
+              }
+
+              for (const duplicate of related) {
+                const duplicateLabels = duplicate.labels.map(label => label.name);
+                for (const label of ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'needs-improvement', 'passed', 'late-submission']) {
+                  if (!duplicateLabels.includes(label)) continue;
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      issue_number: duplicate.number,
+                      name: label
+                    });
+                  } catch (_) {}
+                }
+                if (!duplicateLabels.includes('duplicate')) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: duplicate.number,
+                    labels: ['duplicate']
+                  });
+                }
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: duplicate.number,
+                  state: 'closed',
+                  state_reason: 'not_planned'
+                });
+                const marker = `<!-- dep-repair-duplicate:${canonical.number} -->`;
+                const duplicateComments = await github.paginate(github.rest.issues.listComments, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: duplicate.number,
+                  per_page: 100
+                });
+                if (!duplicateComments.some(comment => (comment.body || '').includes(marker))) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: duplicate.number,
+                    body: `${marker}\nThis issue has been consolidated into canonical on-time submission #${canonical.number}. Continue there; its original deadline eligibility is preserved.`
+                  });
+                }
+              }
+            }
+
+            core.summary.addHeading(`${milestone} gate-closure repair ${dryRun ? 'dry run' : 'apply'}`);
+            if (report.length) core.summary.addList(report);
+            else core.summary.addRaw('No eligible gate-blocked submissions were found.');
+            await core.summary.write();
+            core.setOutput('matrix', dryRun ? JSON.stringify({ include: [] }) : JSON.stringify({ include: canonicalIssues }));
+            core.setOutput('has_repairs', !dryRun && canonicalIssues.length > 0 ? 'true' : 'false');
+
+  reevaluate-canonical-issues:
+    needs: discover-and-consolidate
+    if: inputs.dry_run == false && needs.discover-and-consolidate.outputs.has_repairs == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover-and-consolidate.outputs.matrix) }}
+    uses: ./.github/workflows/_milestone-evaluate.yml
+    with:
+      issue_number: ${{ matrix.issue_number }}
+      check_duplicate: false
+    secrets: inherit

--- a/.github/workflows/milestone-verdict.yml
+++ b/.github/workflows/milestone-verdict.yml
@@ -1,0 +1,183 @@
+name: Milestone Reviewer Verdict
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  apply-needs-improvement:
+    if: >-
+      github.event.label.name == 'needs-improvement' &&
+      contains(github.event.issue.labels.*.name, 'milestone-submission')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: milestone-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - name: Normalize needs-improvement state
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const removable = ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'passed', 'late-submission'];
+            const labels = context.payload.issue.labels.map(label => label.name);
+            if (labels.includes('passed')) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: 'needs-improvement'
+                });
+              } catch (_) {}
+              const marker = '<!-- dep-verdict:terminal-pass -->';
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                per_page: 100
+              });
+              if (!comments.some(comment => (comment.body || '').includes(marker))) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: `${marker}\nThe \`passed\` verdict is terminal because it may already have released the next milestone. Ask the Systems Lead to use the audited manual workflow if this verdict was applied by mistake.`
+                });
+              }
+              return;
+            }
+            for (const label of removable) {
+              if (!labels.includes(label)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label
+                });
+              } catch (_) {}
+            }
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'open'
+            });
+
+  finalize-pass:
+    if: >-
+      github.event.label.name == 'passed' &&
+      contains(github.event.issue.labels.*.name, 'milestone-submission')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: milestone-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    outputs:
+      waiting_issue_number: ${{ steps.finalize.outputs.waiting_issue_number }}
+    steps:
+      - name: Close completed issue and find next waiting milestone
+        id: finalize
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const milestones = ['M0', 'M1', 'M2', 'M3', 'M4', 'M5', 'M6'];
+            const issue = context.payload.issue;
+            const labels = issue.labels.map(label => label.name);
+            const milestone = labels.find(label => /^M[0-6]$/.test(label));
+            if (!labels.includes('ready-for-review')) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: 'passed'
+                });
+              } catch (_) {}
+              const blockedMarker = '<!-- dep-verdict:pass-rejected -->';
+              const existingComments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+              if (!existingComments.some(comment => (comment.body || '').includes(blockedMarker))) {
+                const reason = labels.includes('late-submission')
+                  ? 'This issue is late. Run the manual milestone evaluation with `override_deadline` and an audit reason before applying a verdict.'
+                  : 'This issue has not reached `ready-for-review`. Complete its automated checks and prerequisite gate before applying a verdict.';
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `${blockedMarker}\nThe \`passed\` label was removed. ${reason}`
+                });
+              }
+              core.setOutput('waiting_issue_number', '');
+              return;
+            }
+            const removable = ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'needs-improvement', 'late-submission'];
+            for (const label of removable) {
+              if (!labels.includes(label)) continue;
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: label
+                });
+              } catch (_) {}
+            }
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              state: 'closed',
+              state_reason: 'completed'
+            });
+
+            const marker = `<!-- dep-verdict:${milestone}:passed -->`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              per_page: 100
+            });
+            if (!comments.some(comment => (comment.body || '').includes(marker))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `${marker}\n## Reviewer verdict — passed\n\nThis milestone is complete. If the next milestone was submitted on time while waiting, it will now be released automatically.\n\n---\n_DEP submission bot_`
+              });
+            }
+
+            const index = milestones.indexOf(milestone);
+            if (index < 0 || index === milestones.length - 1) {
+              core.setOutput('waiting_issue_number', '');
+              return;
+            }
+            const next = milestones[index + 1];
+            const candidates = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: `milestone-submission,${next},waiting-on-prerequisite`,
+              state: 'open',
+              per_page: 100
+            });
+            const waiting = candidates
+              .filter(candidate => candidate.user.login.toLowerCase() === issue.user.login.toLowerCase())
+              .filter(candidate => !candidate.labels.some(label => label.name === 'duplicate'))
+              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at))[0];
+            core.setOutput('waiting_issue_number', waiting ? String(waiting.number) : '');
+
+  evaluate-released-submission:
+    needs: finalize-pass
+    if: needs.finalize-pass.outputs.waiting_issue_number != ''
+    uses: ./.github/workflows/_milestone-evaluate.yml
+    with:
+      issue_number: ${{ fromJSON(needs.finalize-pass.outputs.waiting_issue_number) }}
+      check_duplicate: false
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,23 @@ All notable curriculum-documentation changes in this repo should be recorded her
 
 ### Added
 
-No unreleased changes.
+- Added explicit milestone workflow states for submissions waiting on prerequisites, ready for review, and rejected as late.
+- Added automatic release of an on-time M1–M6 submission when the same builder's previous milestone receives a human `passed` verdict.
+- Added maintainer dry-run/apply workflows for audited deadline overrides and repair of historical gate-blocked submissions.
+- Added policy tests for deadline boundaries, repository normalization, milestone sequencing, recheck commands, and state decisions.
+
+### Changed
+
+- Changed prerequisite gates to preserve and validate on-time submissions instead of closing them; revisions now stay on the canonical issue through `/recheck <commit-hash>`.
+- Changed milestone identity matching from repository URL text to the submitting GitHub account so repository renames do not break progression.
+- Changed M0 to require a human verdict after structural checks instead of automatically applying `passed`.
+- Updated the public submission tracker to show closed passed issues plus waiting and ready-for-review queues while excluding duplicate and late attempts from canonical totals.
+
+### Fixed
+
+- Fixed the deadline conflict that rejected replacement issues after an on-time submission was auto-closed for a pending prerequisite.
+- Fixed structural-check failures that instructed builders to recheck without adding the `needs-improvement` state required to trigger the recheck workflow.
+- Fixed duplicate milestone attempts by directing builders back to one canonical issue per milestone.
 
 ## [0.3.0] - 2026-07-08 - Builder Cohort Dashboard and Timeline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable curriculum-documentation changes in this repo should be recorded her
 - Added automatic release of an on-time M1–M6 submission when the same builder's previous milestone receives a human `passed` verdict.
 - Added maintainer dry-run/apply workflows for audited deadline overrides and repair of historical gate-blocked submissions.
 - Added policy tests for deadline boundaries, repository normalization, milestone sequencing, recheck commands, and state decisions.
+- Added a default pull request template covering context, issue linkage, testing, rollout, screenshots, documentation, and privacy checks.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Progress is tracked through 7 milestones (M0–M6). Each one has a clear output 
 | M5 — Public Repo / Predictive Component | By Week 20–23 | Professional repo + predictive layer (Path A) OR advanced EDA + stakeholder brief (Path B) |
 | M6 — Live Deployment | By Week 24 | Live GitHub Pages URL + presentable final project |
 
-> **Gates:** M0 and M1 are hard gates. Learners must not proceed to the next phase without moderator review and approval.
+> **Gates:** Milestones are sequential, and M0/M1 are hard progression gates. Learners may record the next submission before its deadline while a prerequisite review is pending, but they must not proceed until the prerequisite is marked `passed`. The on-time issue stays queued and releases automatically after approval.
 
 Full checklist: [docs/MILESTONE_CHECKLIST.md](docs/MILESTONE_CHECKLIST.md)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -44,7 +44,7 @@ Yes. The pacing is meant to work for students and working professionals, but you
 
 **Q: What happens if I miss a milestone deadline?**
 
-Milestones are non-negotiable. Missing deadlines without prior alignment with the organizing team can result in being off-boarded from the official code-review track.
+Milestones are non-negotiable. Missing a first-submission deadline without prior alignment with the organizing team can result in being off-boarded from the official code-review track. If you submitted on time while the previous milestone was still awaiting review, your issue remains eligible in the prerequisite queue. Do not open a replacement issue; post `/recheck <40-character-hash>` on the original issue if revisions are requested.
 
 **Q: I don't know what project to build. What do I do?**
 

--- a/docs/MILESTONE_CHECKLIST.md
+++ b/docs/MILESTONE_CHECKLIST.md
@@ -2,11 +2,13 @@
 
 Use this to track your progress. Milestone reviewers also use this when evaluating submissions.
 
+Submit one issue per milestone before its deadline. If the previous milestone is still awaiting review, the new issue remains open as `waiting-on-prerequisite`; its submission time is preserved and it releases automatically after the prerequisite passes. If revisions are requested, push a new commit and comment `/recheck <40-character-hash>` on the same issue. Do not open a replacement issue.
+
 ---
 
 ## M0 — Problem Statement *(End of Week 1)*
 
-> ⚡ **Hard gate.** If you cannot pass M0, you must not proceed. Moderator review required.
+> ⚡ **Hard gate.** If you cannot pass M0, you must not proceed. Automated checks only validate the repository snapshot; a human moderator makes the final M0 verdict.
 
 - [ ] Problem is framed as a **specific, answerable question** (not just a topic)
 - [ ] Intended audience is clearly identified
@@ -20,7 +22,7 @@ Use this to track your progress. Milestone reviewers also use this when evaluati
 
 ## M1 — Data Source Identified / Repo Initialized *(By Week 3–4)*
 
-> ⚡ **Gate.** Week 2 deliverable (data source) must be reviewed and marked complete before Week 3 repo setup begins. Vague sources do not pass. Moderator must confirm the source is specific and usable.
+> ⚡ **Gate.** Week 2 deliverable (data source) must be reviewed and marked complete before Week 3 repo setup begins. Vague sources do not pass. An on-time M1 issue may wait in the prerequisite queue, but work must not advance until M0 passes.
 
 - [ ] Working public repo with starter folder structure + first commit
 - [ ] Chosen data source is specific and usable — not vague

--- a/docs/VOLUNTEER_GUIDE.md
+++ b/docs/VOLUNTEER_GUIDE.md
@@ -23,6 +23,9 @@ Review Builder submissions using the checklist in [MILESTONE_CHECKLIST.md](MILES
 - Check submissions within 3–5 days of the deadline
 - Use the checklist — don't improvise criteria
 - Leave one specific, actionable comment when marking Improve
+- Review issues labeled `ready-for-review`; issues labeled `waiting-on-prerequisite` are recorded but not yet ready for a verdict
+- Apply `passed` only after the full human checklist is satisfied, including M0; applying it closes the issue and releases the builder's next queued milestone
+- Apply `needs-improvement` when revisions are required. Do not remove a terminal `passed` label directly; escalate an accidental verdict to the Systems Lead for an audited correction
 
 ### Community Moderators
 Keep the Discord healthy. Answer questions async. Encourage progress.
@@ -63,6 +66,8 @@ A builder should never be blocked on a milestone for more than 7 days due to rev
 | Day 5 | Community Moderator | Ping the assigned reviewer in the volunteer channel if no verdict yet |
 | Day 7 | System Lead | Step in directly — either review it or reassign to another available reviewer |
 
+The prerequisite queue protects builders from reviewer timing. An on-time next-milestone issue must stay open while the previous review is pending and must not be treated as a late submission when it is released.
+
 **If you cannot review a submission you've been assigned:**
 
 - Post in the volunteer channel as early as possible so someone else can pick it up
@@ -77,6 +82,7 @@ A builder should never be blocked on a milestone for more than 7 days due to rev
 - Run live lectures or synchronous sessions
 - Write code for Builders
 - Approve late submissions outside the policy
+- Ask builders to open replacement milestone issues; revisions belong on the canonical issue as `/recheck <40-character-hash>`
 - Make unilateral changes to the curriculum repo
 
 For curriculum changes, open a PR. For policy questions, raise it with the program lead.

--- a/docs/assets/progress.css
+++ b/docs/assets/progress.css
@@ -29,7 +29,7 @@
 .progress-stats {
   display: grid;
   gap: 12px;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   margin-bottom: 24px;
 }
 
@@ -52,6 +52,10 @@
 
 .progress-stat-card.pending .number {
   color: #93c5fd;
+}
+
+.progress-stat-card.waiting .number {
+  color: #fde68a;
 }
 
 .progress-stat-card.improvement .number {
@@ -227,6 +231,18 @@
   background: #3d2f1a;
   border: 1px solid #92400e;
   color: #fcd34d;
+}
+
+.progress-badge.waiting-on-prerequisite {
+  background: #3b3218;
+  border: 1px solid #a16207;
+  color: #fde68a;
+}
+
+.progress-badge.ready-for-review {
+  background: #142f4f;
+  border: 1px solid #1d4ed8;
+  color: #bfdbfe;
 }
 
 .progress-badge.pending-review {

--- a/docs/assets/progress.js
+++ b/docs/assets/progress.js
@@ -7,6 +7,7 @@ let enrolledSet = null;
 let viewMode = "enrolled";
 
 const sortState = {
+  waiting: { col: "days", dir: "desc" },
   pending: { col: "days", dir: "desc" },
   improvement: { col: "days", dir: "desc" },
   all: { col: "days", dir: "desc" },
@@ -21,6 +22,8 @@ function getStatus(labels) {
   const names = labels.map((label) => label.name);
   if (names.includes("passed")) return "passed";
   if (names.includes("needs-improvement")) return "needs-improvement";
+  if (names.includes("waiting-on-prerequisite")) return "waiting-on-prerequisite";
+  if (names.includes("ready-for-review")) return "ready-for-review";
   if (names.includes("auto-check-pending")) return "checking";
   return "pending-review";
 }
@@ -46,6 +49,8 @@ function statusBadge(status) {
   const map = {
     passed: ["passed", "Passed"],
     "needs-improvement": ["needs-improvement", "Needs Improvement"],
+    "waiting-on-prerequisite": ["waiting-on-prerequisite", "Waiting on prerequisite"],
+    "ready-for-review": ["ready-for-review", "Ready for review"],
     "pending-review": ["pending-review", "Pending Review"],
     checking: ["checking", "Checking"],
   };
@@ -55,6 +60,9 @@ function statusBadge(status) {
 
 function daysBadge(days, status) {
   if (status === "passed") return `<span class="progress-days ok">${days}d</span>`;
+  if (status === "waiting-on-prerequisite") {
+    return `<span class="progress-days warn">${days}d queued</span>`;
+  }
   if (days >= 5) return `<span class="progress-days breach">${days}d overdue</span>`;
   if (days >= 3) return `<span class="progress-days warn">${days}d waiting</span>`;
   return `<span class="progress-days ok">${days}d</span>`;
@@ -190,17 +198,24 @@ function buildTable(issues, tableKey) {
 }
 
 function renderAll() {
-  const pending = allIssues.filter((issue) => issue._status === "pending-review");
+  const waiting = allIssues.filter((issue) => issue._status === "waiting-on-prerequisite");
+  const pending = allIssues.filter(
+    (issue) => issue._status === "ready-for-review" || issue._status === "pending-review",
+  );
   const improvement = allIssues.filter((issue) => issue._status === "needs-improvement");
 
+  document.getElementById("queue-waiting").innerHTML = buildTable(waiting, "waiting");
   document.getElementById("queue-pending").innerHTML = buildTable(pending, "pending");
   document.getElementById("queue-improvement").innerHTML = buildTable(improvement, "improvement");
   document.getElementById("queue-all").innerHTML = buildTable(allIssues, "all");
 
   const visible = applyFilters(allIssues);
   document.getElementById("s-total").textContent = visible.length;
+  document.getElementById("s-waiting").textContent = visible.filter(
+    (issue) => issue._status === "waiting-on-prerequisite",
+  ).length;
   document.getElementById("s-pending").textContent = visible.filter(
-    (issue) => issue._status === "pending-review",
+    (issue) => issue._status === "ready-for-review" || issue._status === "pending-review",
   ).length;
   document.getElementById("s-improvement").textContent = visible.filter(
     (issue) => issue._status === "needs-improvement",
@@ -241,11 +256,17 @@ async function fetchAll() {
   let page = 1;
   while (true) {
     const response = await fetch(
-      `https://api.github.com/repos/${OWNER}/${REPO}/issues?labels=milestone-submission&state=open&per_page=100&page=${page}`,
+      `https://api.github.com/repos/${OWNER}/${REPO}/issues?labels=milestone-submission&state=all&per_page=100&page=${page}`,
     );
     const batch = await response.json();
     if (!Array.isArray(batch) || !batch.length) break;
-    issues = issues.concat(batch.filter((issue) => !issue.pull_request));
+    issues = issues.concat(
+      batch.filter(
+        (issue) =>
+          !issue.pull_request &&
+          !issue.labels.some((label) => label.name === "duplicate" || label.name === "late-submission"),
+      ),
+    );
     if (batch.length < 100) break;
     page += 1;
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1024,11 +1024,15 @@
                                     What happens if I miss a milestone deadline?
                                 </summary>
                                 <p>
-                                    Milestones are non-negotiable. Missing
-                                    deadlines without prior alignment with the
-                                    organizing team can result in being
-                                    off-boarded from the official code-review
-                                    track.
+                                    Milestones are non-negotiable. Missing a
+                                    first-submission deadline without prior
+                                    alignment with the organizing team can
+                                    result in being off-boarded from the
+                                    official code-review track. An on-time
+                                    issue remains eligible if it is waiting for
+                                    the previous milestone to pass. Continue on
+                                    that original issue instead of opening a
+                                    replacement.
                                 </p>
                             </details>
                             <details class="reveal">

--- a/docs/progress.html
+++ b/docs/progress.html
@@ -9,7 +9,7 @@
         />
         <title>Submission Tracker — DEP Engineering Program</title>
         <link rel="stylesheet" href="assets/site.css?v=10" />
-        <link rel="stylesheet" href="assets/progress.css?v=1" />
+        <link rel="stylesheet" href="assets/progress.css?v=2" />
     </head>
     <body>
         <a class="skip-link" href="#main">Skip to content</a>
@@ -108,6 +108,10 @@
                     <span class="number" id="s-pending">—</span>
                     <span class="label">Pending review</span>
                 </article>
+                <article class="progress-stat-card waiting">
+                    <span class="number" id="s-waiting">—</span>
+                    <span class="label">Waiting on gate</span>
+                </article>
                 <article class="progress-stat-card improvement">
                     <span class="number" id="s-improvement">—</span>
                     <span class="label">Needs improvement</span>
@@ -146,11 +150,20 @@
                 <select id="filter-status" onchange="renderAll()">
                     <option value="">All statuses</option>
                     <option value="pending-review">Pending review</option>
+                    <option value="ready-for-review">Ready for review</option>
+                    <option value="waiting-on-prerequisite">Waiting on prerequisite</option>
                     <option value="needs-improvement">Needs improvement</option>
                     <option value="passed">Passed</option>
                     <option value="checking">Checking</option>
                 </select>
             </div>
+
+            <section class="progress-section" aria-labelledby="waiting-queue-title">
+                <h2 id="waiting-queue-title">On-time submissions waiting on a prerequisite</h2>
+                <div id="queue-waiting">
+                    <div class="progress-loading">Loading…</div>
+                </div>
+            </section>
 
             <section class="progress-section" aria-labelledby="pending-queue-title">
                 <h2 id="pending-queue-title">Pending reviewer action</h2>
@@ -201,6 +214,6 @@
         </footer>
 
         <script src="assets/site.js?v=9"></script>
-        <script src="assets/progress.js?v=1"></script>
+        <script src="assets/progress.js?v=2"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary

- Preserve on-time milestone submissions when a prerequisite review is still pending instead of closing them and forcing a late replacement.
- Unify initial checks, rechecks, manual evaluations, reviewer verdicts, and automatic release around one milestone state model.
- Add an audited repair workflow for historical gate closures and update builder guidance plus the public tracker.
- Add a default pull request template so future contributions consistently document context, tests, rollout, and privacy checks.

## Related issues

Related submission cases: #86, #113, #135, #119, #90, #100, #116, #72, and #128.

These are milestone submissions and should not be closed automatically by this PR.

## Changes

- Match prerequisite passes by the submitting GitHub account rather than repository URL text.
- Keep valid submissions open as `waiting-on-prerequisite`, `needs-improvement`, or `ready-for-review` and preserve their original timestamps.
- Require a human reviewer verdict for M0 and automatically reevaluate the next waiting milestone after a pass.
- Keep revisions on one canonical issue through `/recheck <40-character-hash>` and reject duplicate replacement issues.
- Provide dry-run/apply repair tooling for historical gate-blocked submissions while preserving terminal passed verdicts.
- Surface waiting and ready-for-review states in templates, reviewer documentation, and the public submission tracker.

## Test plan

- [x] `pytest .github/scripts -q` — 34 tests passed
- [x] `node --check docs/assets/progress.js`
- [x] Parse all workflow and issue-template YAML files
- [x] Validate embedded `actions/github-script` blocks in their async execution context
- [x] Validate tracker HTML IDs against JavaScript references
- [x] `git diff --check`
- [ ] Verify the workflows from the default branch after merge
- [ ] Preview the updated submission tracker after GitHub Pages deploys

## Rollout / follow-up

- [ ] Run the M1 repair workflow with `dry_run: true` and inspect every canonical/duplicate mapping.
- [ ] Apply the reviewed M1 repair to restore cases including #119 and #116.
- [ ] Run and apply the M2 repair for on-time gate-blocked submissions including #128.
- [ ] Manually reevaluate #90, #100, and #72 because they are not historical gate-closure cases.
- [ ] Confirm waiting, needs-improvement, and ready-for-review labels appear correctly on GitHub and the public tracker.

## Screenshots

N/A — the tracker update adds status cards, filters, and queues; post-deploy visual verification remains in the rollout checklist.

## Checklist

- [x] The PR is focused and I reviewed my own changes
- [x] Tests and manual verification are documented above
- [x] Documentation and `CHANGELOG.md` are updated
- [x] No credentials, private notes, personal data, or internal links are exposed
- [x] Rollout and compatibility considerations are documented
