### PR TITLE
Feat/remove milestone check gates

### DIFF
--- a/.github/ISSUE_TEMPLATE/milestone-m0.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m0.yml
@@ -8,7 +8,8 @@ body:
       value: |
         **Milestone 0 — Project Proposal**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
-        Submit once before the deadline. If changes are requested, comment `/recheck <40-character-hash>` on this same issue instead of opening another one.
+        Aim to submit before the target deadline. Late submissions remain open, continue through normal evaluation, and receive a `late-submission` indicator.
+        Submit once. If changes are requested, comment `/recheck <40-character-hash>` on this same issue instead of opening another one.
         Automated checks verify the repository snapshot; a human reviewer makes the final M0 verdict.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/milestone-m1.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m1.yml
@@ -9,7 +9,8 @@ body:
         **Milestone 1 — Foundations Complete**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
         M1 is a **hard gate** — moderator review required before you proceed to Phase 2.
-        If M0 is still awaiting review, an on-time M1 issue stays open in the prerequisite queue and releases automatically after M0 passes.
+        If M0 is still awaiting review, the M1 issue stays open in the prerequisite queue and releases automatically after M0 passes.
+        Submissions after the target deadline are flagged late but follow the same evaluation path.
         Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/milestone-m2.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m2.yml
@@ -8,7 +8,8 @@ body:
       value: |
         **Milestone 2 — Data Ingestion**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
-        If M1 is still awaiting review, an on-time M2 issue stays open in the prerequisite queue and releases automatically after M1 passes.
+        If M1 is still awaiting review, the M2 issue stays open in the prerequisite queue and releases automatically after M1 passes.
+        Submissions after the target deadline are flagged late but follow the same evaluation path.
         Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/milestone-m3.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m3.yml
@@ -8,7 +8,8 @@ body:
       value: |
         **Milestone 3 — Data Processing**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
-        If M2 is still awaiting review, an on-time M3 issue stays open in the prerequisite queue and releases automatically after M2 passes.
+        If M2 is still awaiting review, the M3 issue stays open in the prerequisite queue and releases automatically after M2 passes.
+        Submissions after the target deadline are flagged late but follow the same evaluation path.
         Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/milestone-m4.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m4.yml
@@ -8,7 +8,8 @@ body:
       value: |
         **Milestone 4 — Analysis & Insights**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
-        If M3 is still awaiting review, an on-time M4 issue stays open in the prerequisite queue and releases automatically after M3 passes.
+        If M3 is still awaiting review, the M4 issue stays open in the prerequisite queue and releases automatically after M3 passes.
+        Submissions after the target deadline are flagged late but follow the same evaluation path.
         Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/milestone-m5.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m5.yml
@@ -9,7 +9,8 @@ body:
         **Milestone 5 — Predictive / Alt Track**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
         Indicate which path you took (Path A or Path B) in the notes field.
-        If M4 is still awaiting review, an on-time M5 issue stays open in the prerequisite queue and releases automatically after M4 passes.
+        If M4 is still awaiting review, the M5 issue stays open in the prerequisite queue and releases automatically after M4 passes.
+        Submissions after the target deadline are flagged late but follow the same evaluation path.
         Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/milestone-m6.yml
+++ b/.github/ISSUE_TEMPLATE/milestone-m6.yml
@@ -9,7 +9,8 @@ body:
         **Milestone 6 — Live Deployment**
         Fill in all fields. The auto-checker runs as soon as you submit this issue.
         Congratulations on reaching the final milestone!
-        If M5 is still awaiting review, an on-time M6 issue stays open in the prerequisite queue and releases automatically after M5 passes.
+        If M5 is still awaiting review, the M6 issue stays open in the prerequisite queue and releases automatically after M5 passes.
+        Submissions after the target deadline are flagged late but follow the same evaluation path.
         Submit once. For revisions, comment `/recheck <40-character-hash>` on this same issue.
 
   - type: input

--- a/.github/scripts/milestone_policy.py
+++ b/.github/scripts/milestone_policy.py
@@ -1,7 +1,7 @@
 """Pure policy helpers for milestone tooling and regression tests.
 
 GitHub API mutations stay in the workflows. Keeping parsing and state decisions
-here makes the deadline, identity, and milestone rules independently testable.
+here makes deadline classification, identity, and milestone rules independently testable.
 """
 
 from __future__ import annotations
@@ -18,8 +18,8 @@ STATE_LABELS = (
     "ready-for-review",
     "needs-improvement",
     "passed",
-    "late-submission",
 )
+METADATA_LABELS = ("late-submission",)
 
 
 def extract_field(body: str, heading: str) -> str:
@@ -66,6 +66,11 @@ def is_on_time(created_at: str, deadline: str) -> bool:
     return parse_timestamp(created_at) <= parse_timestamp(deadline)
 
 
+def is_late(created_at: str, deadline: str) -> bool:
+    """Return whether a submission should receive informational late metadata."""
+    return parse_timestamp(created_at) > parse_timestamp(deadline)
+
+
 def previous_milestone(milestone: str) -> str | None:
     try:
         index = MILESTONES.index(milestone.upper())
@@ -93,10 +98,8 @@ def extract_recheck_hash(comment: str) -> str:
     return ""
 
 
-def decide_state(*, deadline_ok: bool, snapshot_ok: bool, prerequisite_ok: bool) -> str:
+def decide_state(*, snapshot_ok: bool, prerequisite_ok: bool) -> str:
     """Return the single workflow state that should follow evaluation."""
-    if not deadline_ok:
-        return "late-submission"
     if not snapshot_ok:
         return "needs-improvement"
     if not prerequisite_ok:

--- a/.github/scripts/test_milestone_policy.py
+++ b/.github/scripts/test_milestone_policy.py
@@ -3,11 +3,14 @@ from datetime import timezone
 import pytest
 
 from milestone_policy import (
+    METADATA_LABELS,
     MILESTONES,
+    STATE_LABELS,
     choose_latest_on_time,
     decide_state,
     extract_field,
     extract_recheck_hash,
+    is_late,
     is_on_time,
     next_milestone,
     normalize_repo_url,
@@ -41,7 +44,14 @@ def test_deadline_boundary_uses_timezone_offset():
     deadline = "2026-07-12T23:59:59+08:00"
     assert is_on_time("2026-07-12T15:59:59Z", deadline)
     assert not is_on_time("2026-07-12T16:00:00Z", deadline)
+    assert not is_late("2026-07-12T15:59:59Z", deadline)
+    assert is_late("2026-07-12T16:00:00Z", deadline)
     assert parse_timestamp(deadline).astimezone(timezone.utc).isoformat() == "2026-07-12T15:59:59+00:00"
+
+
+def test_late_submission_is_metadata_not_a_terminal_state():
+    assert "late-submission" in METADATA_LABELS
+    assert "late-submission" not in STATE_LABELS
 
 
 def test_all_milestone_neighbors_are_sequential():
@@ -67,17 +77,15 @@ def test_extract_recheck_hash(comment, expected):
 
 
 @pytest.mark.parametrize(
-    ("deadline_ok", "snapshot_ok", "prerequisite_ok", "expected"),
+    ("snapshot_ok", "prerequisite_ok", "expected"),
     [
-        (False, True, True, "late-submission"),
-        (True, False, True, "needs-improvement"),
-        (True, True, False, "waiting-on-prerequisite"),
-        (True, True, True, "ready-for-review"),
+        (False, True, "needs-improvement"),
+        (True, False, "waiting-on-prerequisite"),
+        (True, True, "ready-for-review"),
     ],
 )
-def test_decide_state(deadline_ok, snapshot_ok, prerequisite_ok, expected):
+def test_decide_state(snapshot_ok, prerequisite_ok, expected):
     assert decide_state(
-        deadline_ok=deadline_ok,
         snapshot_ok=snapshot_ok,
         prerequisite_ok=prerequisite_ok,
     ) == expected

--- a/.github/workflows/_milestone-evaluate.yml
+++ b/.github/workflows/_milestone-evaluate.yml
@@ -14,14 +14,6 @@ on:
         required: false
         type: boolean
         default: false
-      override_deadline:
-        required: false
-        type: boolean
-        default: false
-      audit_reason:
-        required: false
-        type: string
-        default: ""
     secrets:
       DISCORD_WEBHOOK_URL:
         required: false
@@ -45,33 +37,28 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Load issue and enforce submission eligibility
+      - name: Load issue and classify submission
         id: submission
         uses: actions/github-script@v7
         env:
           ISSUE_NUMBER: ${{ inputs.issue_number }}
           INPUT_COMMIT_HASH: ${{ inputs.commit_hash }}
           CHECK_DUPLICATE: ${{ inputs.check_duplicate }}
-          OVERRIDE_DEADLINE: ${{ inputs.override_deadline }}
-          AUDIT_REASON: ${{ inputs.audit_reason }}
         with:
           script: |
             const fs = require('fs');
             const issueNumber = Number(process.env.ISSUE_NUMBER);
-            const overrideDeadline = process.env.OVERRIDE_DEADLINE === 'true';
-            const auditReason = (process.env.AUDIT_REASON || '').trim();
             const stateLabels = [
               'auto-check-pending',
               'waiting-on-prerequisite',
               'ready-for-review',
               'needs-improvement',
-              'passed',
-              'late-submission'
+              'passed'
             ];
             const labelDefinitions = {
               'waiting-on-prerequisite': {
                 color: 'FBCA04',
-                description: 'On-time submission waiting for the previous milestone to pass'
+                description: 'Submission waiting for the previous milestone to pass'
               },
               'ready-for-review': {
                 color: '1D76DB',
@@ -79,7 +66,7 @@ jobs:
               },
               'late-submission': {
                 color: 'B60205',
-                description: 'First submission was created after the milestone deadline'
+                description: 'Submission was created after the milestone target deadline'
               }
             };
 
@@ -113,11 +100,6 @@ jobs:
               core.notice(`Issue #${issueNumber} is already passed; evaluation skipped.`);
               return;
             }
-            if (overrideDeadline && !auditReason) {
-              core.setFailed('An audit reason is required when overriding a deadline.');
-              return;
-            }
-
             const body = issue.body || '';
             const extract = heading => {
               const match = body.match(new RegExp(`###\\s+${heading}\\s*\\n+([^\\n#]+)`, 'i'));
@@ -223,9 +205,17 @@ jobs:
 
             const deadlines = JSON.parse(fs.readFileSync('.github/milestone-deadlines.json', 'utf8'));
             const deadline = deadlines[milestone];
-            const deadlineOk = !deadline || new Date(issue.created_at) <= new Date(deadline) || overrideDeadline;
-            if (!deadlineOk) {
+            const isLate = Boolean(deadline) && new Date(issue.created_at) > new Date(deadline);
+            if (isLate) {
               const marker = `<!-- dep-eval:${milestone}:late-submission -->`;
+              if (!labelNames.includes('late-submission')) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  labels: ['late-submission']
+                });
+              }
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -240,12 +230,9 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                  body: `${marker}\n## Auto-Check Results — ${milestone}\n\n> ⛔ **Deadline passed.** The ${milestone} deadline was **${deadlinePht} PHT**.\n\nThis is a new issue created after the cutoff. If you had an earlier on-time issue, continue on that issue instead.\n\n---\n_DEP submission bot_`
+                  body: `${marker}\n## Deadline notice — ${milestone}\n\n> ⚠️ **Submitted after the target deadline.** The ${milestone} target deadline was **${deadlinePht} PHT**.\n\nThis issue will remain open and continue through the normal automated checks, prerequisite queue, and reviewer process. Continue using this issue for any revisions.\n\n---\n_DEP submission bot_`
                 });
               }
-              await transition('late-submission', true);
-              core.setOutput('stop', 'true');
-              return;
             }
 
             core.setOutput('stop', 'false');
@@ -254,8 +241,6 @@ jobs:
             core.setOutput('commit_hash', commitHash);
             core.setOutput('issue_author', issue.user.login);
             core.setOutput('was_ready', labelNames.includes('ready-for-review') ? 'true' : 'false');
-            core.setOutput('deadline_overridden', overrideDeadline ? 'true' : 'false');
-            core.setOutput('audit_reason', auditReason);
 
       - name: Clone submitted snapshot
         id: clone
@@ -336,8 +321,6 @@ jobs:
           GATE_OK: ${{ steps.gate.outputs.gate_ok }}
           PREVIOUS_MILESTONE: ${{ steps.gate.outputs.previous }}
           WAS_READY: ${{ steps.submission.outputs.was_ready }}
-          DEADLINE_OVERRIDDEN: ${{ steps.submission.outputs.deadline_overridden }}
-          AUDIT_REASON: ${{ steps.submission.outputs.audit_reason }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:
           script: |
@@ -369,8 +352,7 @@ jobs:
               'auto-check-pending',
               'waiting-on-prerequisite',
               'ready-for-review',
-              'needs-improvement',
-              'late-submission'
+              'needs-improvement'
             ];
             for (const label of stateLabels) {
               if (label === target || !currentLabels.includes(label)) continue;
@@ -418,9 +400,9 @@ jobs:
             }
             let guidance;
             if (target === 'needs-improvement') {
-              guidance = '**Action required:** Fix the problems above, push a commit, then comment `/recheck <40-character-hash>` on this issue. Your original on-time submission date remains preserved.';
+              guidance = '**Action required:** Fix the problems above, push a commit, then comment `/recheck <40-character-hash>` on this issue. Your original submission date remains preserved.';
             } else if (target === 'waiting-on-prerequisite') {
-              guidance = `**Submission recorded on time.** This issue will remain open until ${process.env.PREVIOUS_MILESTONE} is marked \`passed\`. It will then be checked again and released automatically. Do not open another issue.`;
+              guidance = `**Submission recorded.** This issue will remain open until ${process.env.PREVIOUS_MILESTONE} is marked \`passed\`. It will then be checked again and released automatically. Do not open another issue.`;
             } else {
               guidance = process.env.MILESTONE === 'M0'
                 ? '**Ready for human review.** The automated structural checks passed; a reviewer must assess the problem statement, audience, and data source before applying `passed`.'
@@ -434,14 +416,11 @@ jobs:
               per_page: 100
             });
             if (!comments.some(comment => (comment.body || '').includes(marker))) {
-              const overrideNote = process.env.DEADLINE_OVERRIDDEN === 'true'
-                ? `\n\n> Deadline override recorded: ${process.env.AUDIT_REASON}`
-                : '';
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                body: `${marker}\n## Evaluation Results — ${process.env.MILESTONE}\n\n${details}\n\n${guidance}${overrideNote}\n\n---\n_DEP submission bot_`
+                body: `${marker}\n## Evaluation Results — ${process.env.MILESTONE}\n\n${details}\n\n${guidance}\n\n---\n_DEP submission bot_`
               });
             }
 

--- a/.github/workflows/milestone-check.yml
+++ b/.github/workflows/milestone-check.yml
@@ -13,15 +13,6 @@ on:
         description: Optional 40-character commit hash override
         required: false
         type: string
-      override_deadline:
-        description: Allow a late issue through the deadline gate
-        required: true
-        type: boolean
-        default: false
-      audit_reason:
-        description: Required explanation when overriding the deadline
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -46,6 +37,4 @@ jobs:
       issue_number: ${{ inputs.issue_number }}
       commit_hash: ${{ inputs.commit_hash }}
       check_duplicate: false
-      override_deadline: ${{ inputs.override_deadline }}
-      audit_reason: ${{ inputs.audit_reason }}
     secrets: inherit

--- a/.github/workflows/milestone-verdict.yml
+++ b/.github/workflows/milestone-verdict.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const removable = ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'passed', 'late-submission'];
+            const removable = ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'passed'];
             const labels = context.payload.issue.labels.map(label => label.name);
             if (labels.includes('passed')) {
               try {
@@ -105,20 +105,17 @@ jobs:
                 per_page: 100
               });
               if (!existingComments.some(comment => (comment.body || '').includes(blockedMarker))) {
-                const reason = labels.includes('late-submission')
-                  ? 'This issue is late. Run the manual milestone evaluation with `override_deadline` and an audit reason before applying a verdict.'
-                  : 'This issue has not reached `ready-for-review`. Complete its automated checks and prerequisite gate before applying a verdict.';
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  body: `${blockedMarker}\nThe \`passed\` label was removed. ${reason}`
+                  body: `${blockedMarker}\nThe \`passed\` label was removed. This issue has not reached \`ready-for-review\`. Complete its automated checks and prerequisite gate before applying a verdict.`
                 });
               }
               core.setOutput('waiting_issue_number', '');
               return;
             }
-            const removable = ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'needs-improvement', 'late-submission'];
+            const removable = ['auto-check-pending', 'waiting-on-prerequisite', 'ready-for-review', 'needs-improvement'];
             for (const label of removable) {
               if (!labels.includes(label)) continue;
               try {
@@ -150,7 +147,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `${marker}\n## Reviewer verdict — passed\n\nThis milestone is complete. If the next milestone was submitted on time while waiting, it will now be released automatically.\n\n---\n_DEP submission bot_`
+                body: `${marker}\n## Reviewer verdict — passed\n\nThis milestone is complete. If the next milestone was submitted while waiting, it will now be released automatically.\n\n---\n_DEP submission bot_`
               });
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,20 @@ All notable curriculum-documentation changes in this repo should be recorded her
 
 ### Added
 
-- Added explicit milestone workflow states for submissions waiting on prerequisites, ready for review, and rejected as late.
-- Added automatic release of an on-time M1–M6 submission when the same builder's previous milestone receives a human `passed` verdict.
-- Added maintainer dry-run/apply workflows for audited deadline overrides and repair of historical gate-blocked submissions.
+- Added explicit milestone workflow states for submissions waiting on prerequisites or ready for review, plus non-blocking late-submission metadata.
+- Added automatic release of an M1–M6 submission when the same builder's previous milestone receives a human `passed` verdict.
+- Added a maintainer dry-run/apply workflow for repair of historical gate-blocked submissions.
 - Added policy tests for deadline boundaries, repository normalization, milestone sequencing, recheck commands, and state decisions.
 - Added a default pull request template covering context, issue linkage, testing, rollout, screenshots, documentation, and privacy checks.
 - Added a plain-language milestone pipeline guide so cohort mentors can answer common submission, recheck, prerequisite, and review-status questions consistently.
 
 ### Changed
 
-- Changed prerequisite gates to preserve and validate on-time submissions instead of closing them; revisions now stay on the canonical issue through `/recheck <commit-hash>`.
+- Changed milestone deadlines from a hard rejection gate to a visible `late-submission` indicator; late issues remain open and follow the normal evaluation and review path.
+- Changed prerequisite gates to preserve and validate submissions instead of closing them; revisions now stay on the canonical issue through `/recheck <commit-hash>`.
 - Changed milestone identity matching from repository URL text to the submitting GitHub account so repository renames do not break progression.
 - Changed M0 to require a human verdict after structural checks instead of automatically applying `passed`.
-- Updated the public submission tracker to show closed passed issues plus waiting and ready-for-review queues while excluding duplicate and late attempts from canonical totals.
+- Updated the public submission tracker to include evaluated late submissions in queues and totals with a separate Late badge, while continuing to exclude duplicates and legacy late-only closures.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable curriculum-documentation changes in this repo should be recorded her
 - Changed milestone identity matching from repository URL text to the submitting GitHub account so repository renames do not break progression.
 - Changed M0 to require a human verdict after structural checks instead of automatically applying `passed`.
 - Updated the public submission tracker to include evaluated late submissions in queues and totals with a separate Late badge, while continuing to exclude duplicates and legacy late-only closures.
+- Expanded the mentor pipeline guide with separate workflow-status and timing-indicator guidance, late-submission reply templates, and public tracker behavior.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Progress is tracked through 7 milestones (M0–M6). Each one has a clear output 
 | M5 — Public Repo / Predictive Component | By Week 20–23 | Professional repo + predictive layer (Path A) OR advanced EDA + stakeholder brief (Path B) |
 | M6 — Live Deployment | By Week 24 | Live GitHub Pages URL + presentable final project |
 
-> **Gates:** Milestones are sequential, and M0/M1 are hard progression gates. Learners may record the next submission before its deadline while a prerequisite review is pending, but they must not proceed until the prerequisite is marked `passed`. The on-time issue stays queued and releases automatically after approval.
+> **Gates:** Milestones are sequential, and M0/M1 are hard progression gates. Learners may record the next submission while a prerequisite review is pending, but they must not proceed until the prerequisite is marked `passed`. The issue stays queued and releases automatically after approval. Target deadlines remain visible; a late submission is flagged but continues through normal evaluation.
 
 Full checklist: [docs/MILESTONE_CHECKLIST.md](docs/MILESTONE_CHECKLIST.md)
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -36,7 +36,7 @@ The curriculum uses a lean open-source stack: Python, SQL, Git/GitHub, and APIs 
 
 **Q: What is the time commitment required for the cohort?**
 
-You should commit at least 5 hours per week for 6 months, or roughly 120 hours total. The rhythm is self-paced through the week, but milestone deadlines are strictly enforced.
+You should commit at least 5 hours per week for 6 months, or roughly 120 hours total. The rhythm is self-paced through the week, with milestone target deadlines to help you stay on pace.
 
 **Q: I have a full-time job or a heavy school load. Can I still join?**
 
@@ -44,7 +44,7 @@ Yes. The pacing is meant to work for students and working professionals, but you
 
 **Q: What happens if I miss a milestone deadline?**
 
-Milestones are non-negotiable. Missing a first-submission deadline without prior alignment with the organizing team can result in being off-boarded from the official code-review track. If you submitted on time while the previous milestone was still awaiting review, your issue remains eligible in the prerequisite queue. Do not open a replacement issue; post `/recheck <40-character-hash>` on the original issue if revisions are requested.
+Your issue remains open and continues through the normal automated checks, prerequisite queue, and human review. The system adds a `late-submission` indicator so the timing stays visible, but it does not reject or close the issue. Do not open a replacement issue; post `/recheck <40-character-hash>` on the original issue if revisions are requested.
 
 **Q: I don't know what project to build. What do I do?**
 

--- a/docs/MILESTONE_CHECKLIST.md
+++ b/docs/MILESTONE_CHECKLIST.md
@@ -2,7 +2,7 @@
 
 Use this to track your progress. Milestone reviewers also use this when evaluating submissions.
 
-Submit one issue per milestone before its deadline. If the previous milestone is still awaiting review, the new issue remains open as `waiting-on-prerequisite`; its submission time is preserved and it releases automatically after the prerequisite passes. If revisions are requested, push a new commit and comment `/recheck <40-character-hash>` on the same issue. Do not open a replacement issue.
+Aim to submit one issue per milestone by its target deadline. A late issue remains open, receives a `late-submission` indicator, and continues through normal evaluation. If the previous milestone is still awaiting review, the new issue remains open as `waiting-on-prerequisite`; its submission time is preserved and it releases automatically after the prerequisite passes. If revisions are requested, push a new commit and comment `/recheck <40-character-hash>` on the same issue. Do not open a replacement issue.
 
 ---
 
@@ -22,7 +22,7 @@ Submit one issue per milestone before its deadline. If the previous milestone is
 
 ## M1 — Data Source Identified / Repo Initialized *(By Week 3–4)*
 
-> ⚡ **Gate.** Week 2 deliverable (data source) must be reviewed and marked complete before Week 3 repo setup begins. Vague sources do not pass. An on-time M1 issue may wait in the prerequisite queue, but work must not advance until M0 passes.
+> ⚡ **Gate.** Week 2 deliverable (data source) must be reviewed and marked complete before Week 3 repo setup begins. Vague sources do not pass. An M1 issue may wait in the prerequisite queue, but work must not advance until M0 passes.
 
 - [ ] Working public repo with starter folder structure + first commit
 - [ ] Chosen data source is specific and usable — not vague

--- a/docs/MILESTONE_PIPELINE_MENTOR_GUIDE.md
+++ b/docs/MILESTONE_PIPELINE_MENTOR_GUIDE.md
@@ -1,3 +1,7 @@
+# DEP Cohort 1 - CI Playbook
+
+by: `JC Diamante`
+
 # Milestone Pipeline — Plain-Language Mentor Guide
 
 Use this guide when a Builder asks what happened to their milestone submission or what they should do next.
@@ -7,13 +11,16 @@ Use this guide when a Builder asks what happened to their milestone submission o
 ## The One-Minute Explanation
 
 1. The Builder opens **one milestone issue**, ideally by the target deadline.
-2. The system checks the exact repository commit written in the issue.
-3. The issue receives a status explaining what happens next.
-4. If changes are needed, the Builder fixes the project and comments `/recheck <full-commit-hash>` on the same issue.
-5. When the automated checks pass, a human reviewer makes the final decision.
+2. If it was created after the target deadline, the system adds `late-submission` and a deadline notice, but keeps the issue open.
+3. The system checks the exact repository commit written in the issue.
+4. The issue receives a workflow status explaining what happens next.
+5. If changes are needed, the Builder fixes the project and comments `/recheck <full-commit-hash>` on the same issue.
+6. When the automated checks pass, a human reviewer makes the final decision.
 
 ```text
 Submit one issue
+      ↓
+Optional timing indicator: late-submission
       ↓
 Automated checks
       ↓
@@ -25,7 +32,9 @@ Automated checks
 /recheck <commit-hash>   Releases automatically       passed or improve
 ```
 
-## What Each Label Means
+The `late-submission` indicator may appear beside any workflow status below. It records timing only; it does not decide what happens next.
+
+## Workflow Statuses
 
 | Status | Simple meaning | Who acts next? |
 |---|---|---|
@@ -34,7 +43,12 @@ Automated checks
 | `waiting-on-prerequisite` | The submission is recorded, but the previous milestone has not passed. | Nobody needs to resubmit; the system waits. |
 | `ready-for-review` | Automated checks passed. | A human reviewer reviews it. |
 | `passed` | The milestone is complete. | The system releases the next waiting milestone, if one exists. |
-| `late-submission` | The issue was created after the target deadline. This indicator can coexist with the normal workflow status. | Follow the issue's `needs-improvement`, `waiting-on-prerequisite`, `ready-for-review`, or `passed` status. |
+
+## Additional Indicators
+
+| Indicator | Simple meaning | Effect on the issue |
+|---|---|---|
+| `late-submission` | The issue was created after the target deadline. | None. The issue stays open and follows its normal workflow status. The indicator remains visible even after `passed`. |
 | `duplicate` | Another issue is the official submission. | Continue only on the canonical issue named by the bot. |
 
 ## Common Questions and Answers
@@ -54,6 +68,17 @@ The hash must be the full 40-character commit hash. Pushing a commit by itself d
 No. That label only means the first check is still running, so it is normally removed when the check finishes.
 
 Look for the replacement status: `needs-improvement`, `waiting-on-prerequisite`, or `ready-for-review`.
+
+### “My issue has `late-submission`. Was it rejected?”
+
+No. The label records that the issue was created after the target deadline. The bot still checks the submitted commit, applies the normal workflow status, keeps the issue open, and allows the usual reviewer verdict flow.
+
+Read the other status on the issue to determine the next action:
+
+- `needs-improvement`: fix the work and use `/recheck <full-commit-hash>` on the same issue.
+- `waiting-on-prerequisite`: wait for the previous milestone to pass.
+- `ready-for-review`: wait for a human reviewer.
+- `passed`: the milestone is complete; the issue closes as completed, not because it was late.
 
 ### “Do I need to open another issue after failing?”
 
@@ -79,6 +104,10 @@ The automated system only checks basic repository structure. A human must confir
 
 No. The deadline only determines whether the issue has a `late-submission` indicator. The Builder may post a corrected commit on the same issue, and the recheck follows the normal evaluation path.
 
+### “Why is a late submission visible in the public tracker?”
+
+Evaluated late submissions count in the same queues, milestone totals, and aggregate totals as other submissions. The tracker displays a separate **Late** badge beside the current workflow status. Historical issues that were closed by the old deadline-only rejection path remain excluded unless a maintainer reevaluates them.
+
 ### “The bot closed my old issue under the previous pipeline. Should I open a new one?”
 
 No. A maintainer should inspect and, when appropriate, manually reevaluate the original issue. The current pipeline does not automatically reopen historical closures.
@@ -101,6 +130,10 @@ Do not ask the Builder to open another issue. Send the issue to a maintainer for
 
 > Your automated checks passed, and the issue is now waiting for human review. No Builder action is needed unless the reviewer requests changes.
 
+### When the issue was submitted late
+
+> The `late-submission` label records timing only. Your issue remains open and will continue through the normal checks and review process. Follow the other workflow status on the issue for your next action, and keep all revisions on this same issue.
+
 ### When an old issue was closed by the previous pipeline
 
 > Please do not open another issue. We will ask a maintainer to inspect and, when appropriate, reevaluate your original submission.
@@ -110,6 +143,7 @@ Do not ask the Builder to open another issue. Send the issue to a maintainer for
 ### Do
 
 - Point the Builder to the bot's latest comment and current status label.
+- Read `late-submission` separately from the workflow status that determines the next action.
 - Remind the Builder to use the same issue and a full 40-character commit hash.
 - Tell the Builder when no action is required and the reviewer or maintainer must act.
 - Escalate old closed issues, missing statuses, or an incorrect late indicator to a maintainer.
@@ -118,6 +152,7 @@ Do not ask the Builder to open another issue. Send the issue to a maintainer for
 
 - Tell the Builder to create a replacement issue.
 - Tell the Builder that pushing a commit automatically triggers a recheck.
+- Tell the Builder that `late-submission` requires an exception or blocks review.
 - Apply `passed` before the issue reaches `ready-for-review`.
 - Remove a valid late indicator or manually change a terminal verdict.
 

--- a/docs/MILESTONE_PIPELINE_MENTOR_GUIDE.md
+++ b/docs/MILESTONE_PIPELINE_MENTOR_GUIDE.md
@@ -2,11 +2,11 @@
 
 Use this guide when a Builder asks what happened to their milestone submission or what they should do next.
 
-> **Rollout note:** This guide describes the pipeline introduced by [PR #137](https://github.com/dataengineeringpilipinas/dep-data-engineering-open-track/pull/137). Until that PR is merged and the repair steps are run, older issues may still show the previous behavior.
+> **Historical note:** Older late submissions may still be closed under the previous hard-deadline behavior. The current pipeline does not reopen those issues automatically; send one to a maintainer if it needs reevaluation.
 
 ## The One-Minute Explanation
 
-1. The Builder opens **one milestone issue** before the deadline.
+1. The Builder opens **one milestone issue**, ideally by the target deadline.
 2. The system checks the exact repository commit written in the issue.
 3. The issue receives a status explaining what happens next.
 4. If changes are needed, the Builder fixes the project and comments `/recheck <full-commit-hash>` on the same issue.
@@ -25,7 +25,7 @@ Automated checks
 /recheck <commit-hash>   Releases automatically       passed or improve
 ```
 
-## What Each Status Means
+## What Each Label Means
 
 | Status | Simple meaning | Who acts next? |
 |---|---|---|
@@ -34,7 +34,7 @@ Automated checks
 | `waiting-on-prerequisite` | The submission is recorded, but the previous milestone has not passed. | Nobody needs to resubmit; the system waits. |
 | `ready-for-review` | Automated checks passed. | A human reviewer reviews it. |
 | `passed` | The milestone is complete. | The system releases the next waiting milestone, if one exists. |
-| `late-submission` | The first issue was created after the deadline. | A maintainer reviews only an approved exception. |
+| `late-submission` | The issue was created after the target deadline. This indicator can coexist with the normal workflow status. | Follow the issue's `needs-improvement`, `waiting-on-prerequisite`, `ready-for-review`, or `passed` status. |
 | `duplicate` | Another issue is the official submission. | Continue only on the canonical issue named by the bot. |
 
 ## Common Questions and Answers
@@ -57,7 +57,7 @@ Look for the replacement status: `needs-improvement`, `waiting-on-prerequisite`,
 
 ### “Do I need to open another issue after failing?”
 
-No. The Builder should always continue on the same issue so the original deadline and review history are preserved.
+No. The Builder should always continue on the same issue so the original submission time and review history are preserved.
 
 ### “I pushed a new commit. Why did nothing happen?”
 
@@ -65,7 +65,7 @@ The milestone repository cannot automatically see pushes in every Builder reposi
 
 ### “My previous milestone passed later. Do I need to trigger the next submission?”
 
-No. An on-time issue marked `waiting-on-prerequisite` is checked again automatically after the previous milestone passes.
+No. An issue marked `waiting-on-prerequisite` is checked again automatically after the previous milestone passes.
 
 ### “Automated checks passed. Am I done?”
 
@@ -77,11 +77,11 @@ The automated system only checks basic repository structure. A human must confir
 
 ### “Will a recheck be rejected after the deadline?”
 
-An on-time original issue keeps its deadline eligibility. The Builder may post a corrected commit on that same issue after the deadline.
+No. The deadline only determines whether the issue has a `late-submission` indicator. The Builder may post a corrected commit on the same issue, and the recheck follows the normal evaluation path.
 
-### “The bot closed my old on-time issue. Should I open a new one?”
+### “The bot closed my old issue under the previous pipeline. Should I open a new one?”
 
-No. This may be an issue created under the old pipeline, so a maintainer should restore and reevaluate the original on-time submission.
+No. A maintainer should inspect and, when appropriate, manually reevaluate the original issue. The current pipeline does not automatically reopen historical closures.
 
 ### “The issue has no clear status or bot response.”
 
@@ -103,7 +103,7 @@ Do not ask the Builder to open another issue. Send the issue to a maintainer for
 
 ### When an old issue was closed by the previous pipeline
 
-> Please do not open another issue. We will ask a maintainer to restore and reevaluate your original on-time submission.
+> Please do not open another issue. We will ask a maintainer to inspect and, when appropriate, reevaluate your original submission.
 
 ## What Mentors Should and Should Not Do
 
@@ -112,23 +112,23 @@ Do not ask the Builder to open another issue. Send the issue to a maintainer for
 - Point the Builder to the bot's latest comment and current status label.
 - Remind the Builder to use the same issue and a full 40-character commit hash.
 - Tell the Builder when no action is required and the reviewer or maintainer must act.
-- Escalate old closed issues, missing statuses, or approved deadline exceptions to a maintainer.
+- Escalate old closed issues, missing statuses, or an incorrect late indicator to a maintainer.
 
 ### Do not
 
 - Tell the Builder to create a replacement issue.
 - Tell the Builder that pushing a commit automatically triggers a recheck.
 - Apply `passed` before the issue reaches `ready-for-review`.
-- Promise a deadline exception or manually change a terminal verdict.
+- Remove a valid late indicator or manually change a terminal verdict.
 
 ## When to Escalate
 
 Ask a maintainer to inspect the issue when:
 
-- An old on-time submission was closed by the previous pipeline.
+- An old submission was closed by the previous pipeline.
 - The issue has no clear status after the automated run finishes.
 - `/recheck <hash>` was posted correctly but no workflow started.
-- A duplicate or late-submission decision appears incorrect.
+- A duplicate decision or `late-submission` indicator appears incorrect.
 - A `passed` label was applied or removed by mistake.
 
 For milestone requirements and reviewer criteria, use the [Milestone Checklist](MILESTONE_CHECKLIST.md). For volunteer responsibilities and review timing, use the [Volunteer Guide](VOLUNTEER_GUIDE.md).

--- a/docs/VOLUNTEER_GUIDE.md
+++ b/docs/VOLUNTEER_GUIDE.md
@@ -66,7 +66,7 @@ A builder should never be blocked on a milestone for more than 7 days due to rev
 | Day 5 | Community Moderator | Ping the assigned reviewer in the volunteer channel if no verdict yet |
 | Day 7 | System Lead | Step in directly — either review it or reassign to another available reviewer |
 
-The prerequisite queue protects builders from reviewer timing. An on-time next-milestone issue must stay open while the previous review is pending and must not be treated as a late submission when it is released.
+The prerequisite queue protects builders from reviewer timing. A next-milestone issue must stay open while the previous review is pending. Deadline classification uses the issue's original creation time, remains informational, and does not block its release.
 
 **If you cannot review a submission you've been assigned:**
 
@@ -81,7 +81,7 @@ The prerequisite queue protects builders from reviewer timing. An on-time next-m
 
 - Run live lectures or synchronous sessions
 - Write code for Builders
-- Approve late submissions outside the policy
+- Remove a valid `late-submission` indicator or bypass the normal review checklist
 - Ask builders to open replacement milestone issues; revisions belong on the canonical issue as `/recheck <40-character-hash>`
 - Make unilateral changes to the curriculum repo
 

--- a/docs/assets/progress.css
+++ b/docs/assets/progress.css
@@ -221,6 +221,13 @@
   padding: 4px 10px;
 }
 
+.progress-badge-group {
+  align-items: center;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
 .progress-badge.passed {
   background: #1a3d2a;
   border: 1px solid #166534;
@@ -255,6 +262,12 @@
   background: #2a3340;
   border: 1px solid #4b5563;
   color: var(--sub);
+}
+
+.progress-badge.late-submission {
+  background: #421f24;
+  border: 1px solid #b91c1c;
+  color: #fecaca;
 }
 
 .progress-m-badge {

--- a/docs/assets/progress.js
+++ b/docs/assets/progress.js
@@ -1,6 +1,13 @@
 const OWNER = "dataengineeringpilipinas";
 const REPO = "dep-data-engineering-open-track";
 const MILESTONES = ["M0", "M1", "M2", "M3", "M4", "M5", "M6"];
+const PROCESS_LABELS = [
+  "auto-check-pending",
+  "waiting-on-prerequisite",
+  "ready-for-review",
+  "needs-improvement",
+  "passed",
+];
 
 let allIssues = [];
 let enrolledSet = null;
@@ -41,6 +48,7 @@ function enrich(issue) {
     _repoUrl: extract(issue.body, "GitHub Repo URL"),
     _milestone: getMilestone(issue.labels),
     _status: getStatus(issue.labels),
+    _isLate: issue.labels.some((label) => label.name === "late-submission"),
     _days: Math.floor((Date.now() - new Date(issue.created_at).getTime()) / 86400000),
   };
 }
@@ -56,6 +64,13 @@ function statusBadge(status) {
   };
   const [className, label] = map[status] || ["checking", status];
   return `<span class="progress-badge ${className}">${label}</span>`;
+}
+
+function statusBadges(issue) {
+  const lateBadge = issue._isLate
+    ? '<span class="progress-badge late-submission">Late</span>'
+    : "";
+  return `<span class="progress-badge-group">${statusBadge(issue._status)}${lateBadge}</span>`;
 }
 
 function daysBadge(days, status) {
@@ -184,7 +199,7 @@ function buildTable(issues, tableKey) {
       <td><span class="progress-m-badge">${issue._milestone}</span></td>
       <td class="progress-hide-mobile">${formatDate(issue.created_at)}</td>
       <td>${daysBadge(issue._days, issue._status)}</td>
-      <td>${statusBadge(issue._status)}</td>
+      <td>${statusBadges(issue)}</td>
       <td>${
         issue._repoUrl !== "—"
           ? `<a href="${issue._repoUrl}" target="_blank" rel="noopener noreferrer">repo<span class="sr-only"> (opens in new tab)</span></a>`
@@ -262,9 +277,14 @@ async function fetchAll() {
     if (!Array.isArray(batch) || !batch.length) break;
     issues = issues.concat(
       batch.filter(
-        (issue) =>
-          !issue.pull_request &&
-          !issue.labels.some((label) => label.name === "duplicate" || label.name === "late-submission"),
+        (issue) => {
+          const labelNames = issue.labels.map((label) => label.name);
+          const isDuplicate = labelNames.includes("duplicate");
+          const isLegacyLateOnly =
+            labelNames.includes("late-submission") &&
+            !PROCESS_LABELS.some((label) => labelNames.includes(label));
+          return !issue.pull_request && !isDuplicate && !isLegacyLateOnly;
+        },
       ),
     );
     if (batch.length < 100) break;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1001,8 +1001,8 @@
                                     You should commit at least 5 hours per week
                                     for 6 months, or roughly 120 hours total.
                                     The rhythm is self-paced through the week,
-                                    but milestone deadlines are strictly
-                                    enforced.
+                                    with milestone target deadlines to help you
+                                    stay on pace.
                                 </p>
                             </details>
                             <details class="reveal">
@@ -1024,14 +1024,13 @@
                                     What happens if I miss a milestone deadline?
                                 </summary>
                                 <p>
-                                    Milestones are non-negotiable. Missing a
-                                    first-submission deadline without prior
-                                    alignment with the organizing team can
-                                    result in being off-boarded from the
-                                    official code-review track. An on-time
-                                    issue remains eligible if it is waiting for
-                                    the previous milestone to pass. Continue on
-                                    that original issue instead of opening a
+                                    Your issue remains open and continues
+                                    through the normal automated checks,
+                                    prerequisite queue, and human review. The
+                                    system adds a late-submission indicator so
+                                    the timing stays visible, but it does not
+                                    reject or close the issue. Continue on that
+                                    original issue instead of opening a
                                     replacement.
                                 </p>
                             </details>

--- a/docs/progress.html
+++ b/docs/progress.html
@@ -9,7 +9,7 @@
         />
         <title>Submission Tracker — DEP Engineering Program</title>
         <link rel="stylesheet" href="assets/site.css?v=10" />
-        <link rel="stylesheet" href="assets/progress.css?v=2" />
+        <link rel="stylesheet" href="assets/progress.css?v=3" />
     </head>
     <body>
         <a class="skip-link" href="#main">Skip to content</a>
@@ -159,7 +159,7 @@
             </div>
 
             <section class="progress-section" aria-labelledby="waiting-queue-title">
-                <h2 id="waiting-queue-title">On-time submissions waiting on a prerequisite</h2>
+                <h2 id="waiting-queue-title">Submissions waiting on a prerequisite</h2>
                 <div id="queue-waiting">
                     <div class="progress-loading">Loading…</div>
                 </div>
@@ -214,6 +214,6 @@
         </footer>
 
         <script src="assets/site.js?v=9"></script>
-        <script src="assets/progress.js?v=2"></script>
+        <script src="assets/progress.js?v=3"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces hard milestone deadline rejection with a non-blocking `late-submission` indicator so late issues remain open and continue through automated checks, prerequisite gates, and human review.
- Keeps deadline timing visible in GitHub and the public submission tracker without automatically reopening historical late-only closures.
- Aligns milestone issue forms, learner guidance, mentor documentation, website copy, and the changelog with the new soft-deadline policy.

## Related issues

N/A

## Changes

- Refactors the reusable milestone evaluation workflow to label and notify late submissions without stopping evaluation or closing the issue.
- Removes the obsolete manual deadline override and audit-reason inputs.
- Preserves `late-submission` as metadata alongside `needs-improvement`, `waiting-on-prerequisite`, `ready-for-review`, or `passed`.
- Allows reviewers to apply normal verdicts to late submissions while retaining the late indicator for reporting.
- Updates policy helpers and regression tests so deadline classification is independent from workflow state selection.
- Includes evaluated late submissions in tracker queues and totals with a separate Late badge while continuing to exclude duplicates and legacy late-only closures.
- Updates all M0–M6 issue forms and public/maintainer documentation to describe deadlines as target dates rather than automatic rejection gates.

## Test plan

- [x] `python -m pytest .github/scripts -q` — 34 tests passed.
- [x] `node --check docs/assets/progress.js` and `node --check docs/assets/site.js` passed.
- [x] GitHub workflow and issue-template YAML parsed successfully.
- [x] Published HTML parsed successfully and `git diff --check` reported no errors.
- [x] `.github/milestone-deadlines.json` matches `docs/data/milestone-deadlines.json`.
- [x] A local workflow assertion confirmed the late branch cannot stop or close evaluation.
- [x] A tracker simulation confirmed an evaluated late issue is included with both its normal process badge and Late badge, while duplicate and legacy late-only issues remain excluded.
- [ ] After pushing, open a post-deadline test issue and confirm the live GitHub Action keeps it open, applies `late-submission` plus a normal process state, and permits the normal reviewer verdict flow.

## Rollout / follow-up

- No data migration or deadline JSON changes are required.
- Previously auto-closed late issues remain untouched and are not reopened automatically.
- Monitor the first post-deadline milestone issue after merge to confirm the live GitHub Actions event and label sequence matches the verified workflow behavior.
- Confirm the public tracker displays the issue in the correct queue and includes it in aggregate counts after GitHub Pages refreshes.

## Screenshots

- [ ] Add a submission tracker screenshot showing a normal workflow status badge beside the new Late badge after a live late issue is available.

## Checklist

- [x] The PR is focused and I reviewed my own changes
- [x] Tests and manual verification are documented above
- [x] Documentation and `CHANGELOG.md` are updated, or are not applicable
- [x] No credentials, private notes, personal data, or internal links are exposed
- [x] Rollout and compatibility considerations are documented, or are not applicable