### PR TITLE
fix(ci): detect nested files in data directory checks

### DIFF
--- a/.github/scripts/milestone_check.py
+++ b/.github/scripts/milestone_check.py
@@ -19,11 +19,12 @@ def has_file(root: Path, *parts: str) -> bool:
 
 
 def dir_has_real_files(root: Path, *parts: str) -> bool:
-    """True if the directory exists and contains at least one non-.gitkeep file."""
+    """True if the directory exists and contains at least one non-.gitkeep file,
+    searching subdirectories recursively."""
     d = root / Path(*parts)
     if not d.is_dir():
         return False
-    return any(f.name != ".gitkeep" for f in d.iterdir() if f.is_file())
+    return any(f.name != ".gitkeep" for f in d.rglob("*") if f.is_file())
 
 
 def readme_has_content(root: Path, min_chars: int = 100) -> bool:

--- a/.github/scripts/test_milestone_check.py
+++ b/.github/scripts/test_milestone_check.py
@@ -76,6 +76,21 @@ def test_dir_has_real_files_returns_false_when_dir_missing(tmp_path):
     assert not dir_has_real_files(tmp_path, "data", "raw")
 
 
+def test_dir_has_real_files_finds_nested_file(tmp_path):
+    # Regression test for #170: builders group raw files into subdirectories.
+    d = tmp_path / "data" / "raw" / "psa" / "2026"
+    d.mkdir(parents=True)
+    (d / "data.csv").write_text("col1,col2\n1,2")
+    assert dir_has_real_files(tmp_path, "data", "raw")
+
+
+def test_dir_has_real_files_ignores_nested_gitkeep(tmp_path):
+    d = tmp_path / "data" / "raw" / "source_a"
+    d.mkdir(parents=True)
+    (d / ".gitkeep").write_text("")
+    assert not dir_has_real_files(tmp_path, "data", "raw")
+
+
 # ---------------------------------------------------------------------------
 # M1
 # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/scripts/**"
+      - ".github/workflows/ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run milestone script tests
+        run: pytest .github/scripts/ -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this repository are recorded here.
 
 ---
 
+## [0.5.3] - 2026-08-03 — Nested Data Directory Support
+
+### Fixed
+
+- Fixed the M2, M3, and M5 data directory checks ignoring files inside subdirectories of `data/raw/` and `data/processed/`. Builders who group raw files by source or year no longer fail the auto-check with real data committed. (#170)
+
+### Added
+
+- Added a CI workflow that runs the milestone script tests on pull requests touching `.github/scripts/`.
+
+---
+
 ## [0.5.2] - 2026-07-29 — Short Commit Hash Support
 
 ### Fixed


### PR DESCRIPTION
## Summary

- The M2 data check fails builders who organize `data/raw/` into subdirectories, because `dir_has_real_files()` only looks at the top level of the directory.
- This also silently affects the M3 and M5 checks, which use the same helper for `data/processed/`.
- Fix: search recursively with `rglob()`, the same idiom the notebook checks already use. Two regression tests added.
- Adds a small CI workflow so the existing script tests actually run on PRs. Nothing runs them today.

## Related issues

Closes #170

## Changes

- `dir_has_real_files()` in `.github/scripts/milestone_check.py` now walks subdirectories. `.gitkeep` files are still ignored at any depth.
- Two tests: a nested real file passes the check, a nested directory containing only `.gitkeep` still fails it.
- New `.github/workflows/ci.yml`: pytest over `.github/scripts/` on pull requests that touch those files. The 0.5.2 recheck-hash regression is the kind of thing this would have caught.
- CHANGELOG entry for 0.5.3.

## Test plan

- [x] `pytest .github/scripts/ -v`: 36 passed. The new nested-file test fails on main and passes on this branch.
- [x] Verified all three callers of the helper (M2 `data/raw`, M3 and M5 `data/processed`) route through the fixed function; no call-site changes needed.
- [ ] After merge: `/recheck` on an affected submission (e.g. the repo linked in #170) should flip the `data/raw` check to pass.

## Rollout / follow-up

Submissions already marked `needs-improvement` because of this bug do not re-evaluate on their own. Either the affected builders comment `/recheck <hash>`, or a maintainer runs `milestone-check.yml` via workflow dispatch per issue. See follow-up comment below for the list.

## Screenshots

N/A

## Checklist

- [x] The PR is focused and I reviewed my own changes
- [x] Tests and manual verification are documented above
- [x] Documentation and `CHANGELOG.md` are updated, or are not applicable
- [x] No credentials, private notes, personal data, or internal links are exposed
- [x] Rollout and compatibility considerations are documented, or are not applicable
