### PR TITLE
feat(intake): disable blank issues, add bug and waitlist templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,33 @@
+name: "Bug Report"
+description: Report a problem with the milestone pipeline, the docs site, or the curriculum.
+title: "[Bug] <short description>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Bug Report**
+        For milestone submissions, use the Milestone templates instead. This template is for problems with the program itself: the auto-checker, the workflows, the docs site, or curriculum content.
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: What did you see? Paste the exact error message or bot comment if there is one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+
+  - type: input
+    id: reference_link
+    attributes:
+      label: Link to the affected issue, workflow run, or page
+      placeholder: "https://github.com/dataengineeringpilipinas/dep-data-engineering-open-track/..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and help (DEP Discord)
+    url: https://discord.com/invite/buDgydz7J9
+    about: Ask questions in the community channels. Most answers arrive faster there than in an issue.
+  - name: Program FAQ and docs
+    url: https://dataengineeringpilipinas.github.io/dep-data-engineering-open-track/
+    about: Deadlines, recheck instructions, milestone checklists, and common answers.

--- a/.github/ISSUE_TEMPLATE/waitlist.yml
+++ b/.github/ISSUE_TEMPLATE/waitlist.yml
@@ -1,0 +1,61 @@
+name: "Waitlist Application"
+description: The cohort is full but you are building along anyway? Apply for the next open slot.
+title: "[Waitlist] <Your Name>"
+labels: ["waitlist"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Waitlist Application**
+        Slots open when enrolled builders become inactive. When one opens, moderators go through waitlist applications oldest first and enroll the first applicant whose repo shows real progress. You can keep building in the meantime: the milestone checks run against your repo, not your enrollment date, so nothing you do now is wasted.
+
+  - type: input
+    id: builder_name
+    attributes:
+      label: Builder Name
+      placeholder: "e.g. Maria Santos"
+    validations:
+      required: true
+
+  - type: input
+    id: repo_url
+    attributes:
+      label: GitHub Repo URL
+      description: Public URL of your project repo built from the Starter Kit.
+      placeholder: "https://github.com/<your-username>/dep-starter-kit"
+    validations:
+      required: true
+      pattern: ^https?:\/\/github\.com\/[\w.-]+\/[\w.-]+
+      pattern_mismatch_message: "Enter the repository URL (e.g. https://github.com/your-username/dep-starter-kit), not a file or blob URL."
+
+  - type: dropdown
+    id: cohort
+    attributes:
+      label: Cohort
+      options:
+        - "2026-A"
+        - "Open Track"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: milestones_done
+    attributes:
+      label: Milestones you have completed on your own
+      description: Self-assessed. Moderators verify against your repo before enrolling you.
+      options:
+        - label: "M0 — Problem Statement"
+        - label: "M1 — Foundations"
+        - label: "M2 — Data Ingestion"
+        - label: "M3 — Data Processing"
+        - label: "M4 — Analysis & Insights"
+        - label: "M5 — Predictive / Alt Track"
+        - label: "M6 — Live Deployment"
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Optional. Context you want moderators to know.
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this repository are recorded here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added issue intake templates: bug reports (labeled `bug`, kept out of the milestone pipeline) and waitlist applications (labeled `waitlist`) for people building along without a slot. Blank issues are disabled; questions route to Discord and the FAQ via contact links.
+- Documented the slot backfill process for moderators in `VOLUNTEER_GUIDE.md` and added a waitlist FAQ entry.
+
+---
+
 ## [0.5.2] - 2026-07-29 — Short Commit Hash Support
 
 ### Fixed

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -60,6 +60,10 @@ We limit the inaugural cohort to 50 builders so the team can provide meaningful 
 
 Applications are reviewed for foundations, resources, intent, and grit: Python and SQL familiarity, the hardware and internet needed to participate, clear motivation to learn and execute, and visible commitment to finishing the six-month journey.
 
+**Q: The cohort is full. How do I get in?**
+
+Open a [Waitlist Application](https://github.com/dataengineeringpilipinas/dep-data-engineering-open-track/issues/new/choose) issue with a link to your repo. Slots open when enrolled builders become inactive; moderators enroll from the waitlist oldest first, checking claimed progress against the linked repo. Keep building while you wait. Milestone checks run against your repo, not your enrollment date, so work done before enrollment counts the moment you are in.
+
 **Q: If I don't get selected, what are my options?**
 
 Not being selected does not end your journey. You can continue building your skills through free resources from our official partners, DataCamp and WorldQuant University. You can also explore [learning materials](https://dataengineering.ph/resources.html), [past sessions](https://www.youtube.com/@DataEngineeringPilipinas), and [community activities](https://www.meetup.com/data-engineering-pilipinas/) available through the [Data Engineering Pilipinas](https://dataengineering.ph) website. Stay engaged, keep learning, and feel free to apply again in the next cohort cycle.

--- a/docs/VOLUNTEER_GUIDE.md
+++ b/docs/VOLUNTEER_GUIDE.md
@@ -35,6 +35,11 @@ Keep the Discord healthy. Answer questions async. Encourage progress.
 - Redirect to resources before giving direct answers
 - Surface common questions to the program lead
 
+**Slot backfill (when a builder is removed from `enrolled-participants.json`):**
+- Sort open `waitlist` issues oldest first
+- Check the applicant's claimed milestones against their linked repo (the self-check summary in their Actions tab makes this a glance)
+- Add the GitHub login to `.github/enrolled-participants.json`, comment on the waitlist issue, close it
+
 ### Squad Guides *(Optional)*
 Paired with stuck Builders. Limited slots. Only for Builders who are blocked, not those who are slow.
 


### PR DESCRIPTION
## Summary

- Blank issues currently enter the repo with zero labels and float outside every workflow. #7 is a test issue nobody routed, and #170 was a real pipeline bug that sat unlabeled next to milestone submissions.
- Adds a bug report template (labeled `bug`, never touches the auto-checker) and disables blank issues, with contact links pointing questions to Discord and the FAQ.
- Adds a waitlist application template for people doing the track without a slot, plus the moderator process for backfilling freed slots.

## Related issues

N/A

## Changes

- `.github/ISSUE_TEMPLATE/config.yml`: `blank_issues_enabled: false`, contact links to the Discord invite and the docs site.
- `.github/ISSUE_TEMPLATE/bug-report.yml`: what happened / expected / reference link. Safe by construction: the evaluate pipeline's job condition requires both `milestone-submission` and `auto-check-pending`, so `bug` issues never trigger it.
- `.github/ISSUE_TEMPLATE/waitlist.yml`: builder name, repo URL (same pattern validation as milestone templates), cohort, self-assessed milestone checkboxes. Field headings reuse the exact milestone template spelling (`Builder Name`, `GitHub Repo URL`) so the existing `extract()` regex works on these issues if automation ever wants them.
- FAQ entry ("The cohort is full. How do I get in?") and a moderator checklist in `VOLUNTEER_GUIDE.md` for slot backfill: sort waitlist oldest first, verify claimed milestones against the repo, add to `enrolled-participants.json`, close.

## Test plan

- [x] YAML validated against GitHub's issue forms schema locally (yamllint + field-by-field comparison with the working milestone templates).
- [x] Verified the pipeline gating condition in `milestone-check.yml` ignores issues without `milestone-submission` + `auto-check-pending`.
- [ ] After merge: open `/issues/new/choose`, confirm blank issue option is gone and both templates apply their labels.

## Rollout / follow-up

Two labels must exist before this merges or GitHub silently drops them from created issues: `bug` (default, already present) and `waitlist` (needs creating). One `gh label create waitlist` beforehand is the whole migration. Note the blank-issue block applies to maintainers too; if that is unwanted, flip `blank_issues_enabled` back and keep the rest.

## Screenshots

N/A (template renders are in the follow-up comment after a fork test)

## Checklist

- [x] The PR is focused and I reviewed my own changes
- [x] Tests and manual verification are documented above
- [x] Documentation and `CHANGELOG.md` are updated, or are not applicable
- [x] No credentials, private notes, personal data, or internal links are exposed
- [x] Rollout and compatibility considerations are documented, or are not applicable
