### PR TITLE
feat(ci): automate the review SLA, align dashboard staleness to 5/7

### DIFF
--- a/.github/workflows/sla-nag.yml
+++ b/.github/workflows/sla-nag.yml
@@ -1,0 +1,162 @@
+name: Review SLA Check
+
+# Automates the escalation policy documented in docs/VOLUNTEER_GUIDE.md:
+# day 5 a moderator pings the reviewer, day 7 the System Lead steps in,
+# and a builder is never blocked more than 7 days. Days are counted from
+# when the issue entered its current state, not from creation, so a
+# resubmission gets a fresh clock.
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # 10:00 Asia/Manila, daily
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log actions without posting comments or Discord messages
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+
+jobs:
+  sla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check review SLA on open submissions
+        uses: actions/github-script@v7
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const DRY = process.env.DRY_RUN === 'true';
+            const DAY = 86400000;
+
+            const STAGES = [
+              {
+                label: 'ready-for-review',
+                minDays: 7,
+                key: 'ready-for-review:7d',
+                discord: true,
+                message: (issue, days) =>
+                  `This submission has been \`ready-for-review\` for ${days} days, past the 7-day ` +
+                  `limit in the volunteer guide ("a builder should never be blocked on a milestone ` +
+                  `for more than 7 days"). System Lead: please review it directly or reassign.`,
+              },
+              {
+                label: 'ready-for-review',
+                minDays: 5,
+                key: 'ready-for-review:5d',
+                discord: true,
+                message: (issue, days) =>
+                  `This submission has been \`ready-for-review\` for ${days} days. Per the ` +
+                  `escalation policy, moderators: please ping the assigned reviewer in the ` +
+                  `volunteer channel.` +
+                  (issue.assignees.length
+                    ? ` (${issue.assignees.map(a => '@' + a.login).join(', ')})`
+                    : ''),
+              },
+              {
+                label: 'needs-improvement',
+                minDays: 7,
+                key: 'needs-improvement:7d',
+                discord: false,
+                message: (issue, days) =>
+                  `Friendly nudge: this submission has been \`needs-improvement\` for ${days} days. ` +
+                  `When you have pushed a fix, comment \`/recheck <commit-hash>\` here to re-run ` +
+                  `the checks. Stuck? Ask in the Discord community channel.`,
+              },
+            ];
+
+            // When the issue entered its current state: the most recent
+            // "labeled" event for that label.
+            async function labeledDate(issue, label) {
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const labeled = events
+                .filter(e => e.event === 'labeled' && e.label?.name === label)
+                .map(e => e.created_at)
+                .sort();
+              return labeled.length ? labeled[labeled.length - 1] : issue.created_at;
+            }
+
+            async function alreadyNagged(issue, marker) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              return comments.some(c => c.body?.includes(marker));
+            }
+
+            let enrolled = new Set();
+            try {
+              const res = await fetch(
+                `https://raw.githubusercontent.com/${context.repo.owner}/${context.repo.repo}/main/.github/enrolled-participants.json`
+              );
+              const data = await res.json();
+              enrolled = new Set((data.participants || []).map(l => l.toLowerCase()));
+            } catch (e) {
+              core.warning(`Could not load enrolled participants: ${e.message}`);
+            }
+
+            async function sendDiscord(issue, stage, days) {
+              if (!process.env.DISCORD_WEBHOOK_URL) return;
+              if (!enrolled.has(issue.user.login.toLowerCase())) return;
+              const milestone = issue.labels.map(l => l.name).find(n => /^M[0-6]$/.test(n)) || '—';
+              await fetch(process.env.DISCORD_WEBHOOK_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ embeds: [{
+                  title: `⏰ Review SLA — ${milestone} waiting ${days} days`,
+                  color: stage.minDays >= 7 ? 0xB60205 : 0xFBCA04,
+                  fields: [
+                    { name: 'Stage', value: stage.key, inline: true },
+                    { name: 'Issue', value: issue.html_url, inline: false },
+                  ],
+                  timestamp: new Date().toISOString(),
+                }] })
+              });
+            }
+
+            const seen = new Set(); // issue -> highest stage only
+            for (const stage of STAGES) {
+              const issues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: `milestone-submission,${stage.label}`,
+                state: 'open',
+                per_page: 100,
+              });
+              for (const issue of issues.filter(i => !i.pull_request)) {
+                if (seen.has(`${issue.number}:${stage.label}`)) continue;
+                const since = await labeledDate(issue, stage.label);
+                const days = Math.floor((Date.now() - new Date(since).getTime()) / DAY);
+                if (days < stage.minDays) continue;
+                seen.add(`${issue.number}:${stage.label}`);
+
+                const marker = `<!-- dep-sla:${stage.key}:${since} -->`;
+                if (await alreadyNagged(issue, marker)) {
+                  core.info(`#${issue.number} already nagged for ${stage.key}`);
+                  continue;
+                }
+                if (DRY) {
+                  core.notice(`DRY RUN: would post ${stage.key} on #${issue.number} (${days}d)`);
+                  continue;
+                }
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `${marker}\n${stage.message(issue, days)}`,
+                });
+                if (stage.discord) await sendDiscord(issue, stage, days);
+                core.info(`Posted ${stage.key} on #${issue.number} (${days}d)`);
+              }
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this repository are recorded here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added `sla-nag.yml` — daily workflow automating the volunteer guide's Review Escalation Policy: day-5 moderator ping and day-7 System Lead escalation on `ready-for-review` issues (with Discord mirror), plus a day-7 builder nudge on idle `needs-improvement` issues. One comment per stage per review cycle; `dry_run` dispatch input for safe testing.
+
+### Changed
+
+- Changed the progress dashboard staleness badges from 3/5 days to 5/7 days to match the documented escalation policy.
+
+---
+
 ## [0.5.2] - 2026-07-29 — Short Commit Hash Support
 
 ### Fixed

--- a/docs/VOLUNTEER_GUIDE.md
+++ b/docs/VOLUNTEER_GUIDE.md
@@ -66,6 +66,8 @@ A builder should never be blocked on a milestone for more than 7 days due to rev
 | Day 5 | Community Moderator | Ping the assigned reviewer in the volunteer channel if no verdict yet |
 | Day 7 | System Lead | Step in directly — either review it or reassign to another available reviewer |
 
+The day-5 and day-7 reminders are automated: `sla-nag.yml` runs daily, comments on overdue `ready-for-review` issues, and mirrors the ping to Discord. It also nudges builders whose `needs-improvement` issues have been idle for 7 days. The clock starts when the issue enters its current state, so a resubmission is never counted against the previous review round.
+
 The prerequisite queue protects builders from reviewer timing. A next-milestone issue must stay open while the previous review is pending. Deadline classification uses the issue's original creation time, remains informational, and does not block its release.
 
 **If you cannot review a submission you've been assigned:**

--- a/docs/assets/progress.js
+++ b/docs/assets/progress.js
@@ -78,8 +78,10 @@ function daysBadge(days, status) {
   if (status === "waiting-on-prerequisite") {
     return `<span class="progress-days warn">${days}d queued</span>`;
   }
-  if (days >= 5) return `<span class="progress-days breach">${days}d overdue</span>`;
-  if (days >= 3) return `<span class="progress-days warn">${days}d waiting</span>`;
+  // Thresholds match the Review Escalation Policy in docs/VOLUNTEER_GUIDE.md
+  // (day 5 moderator ping, day 7 System Lead) and sla-nag.yml.
+  if (days >= 7) return `<span class="progress-days breach">${days}d overdue</span>`;
+  if (days >= 5) return `<span class="progress-days warn">${days}d waiting</span>`;
   return `<span class="progress-days ok">${days}d</span>`;
 }
 


### PR DESCRIPTION
## Summary

- The volunteer guide has a Review Escalation Policy (day 5: moderator pings the reviewer, day 7: System Lead steps in, and "a builder should never be blocked more than 7 days"). Nothing enforces it; it works when someone remembers.
- Daily workflow that comments on overdue `ready-for-review` issues, mirrors the ping to Discord, and nudges builders whose `needs-improvement` issues sat idle for 7 days.
- The dashboard's staleness badges said 3/5 days for no documented reason; they now match the policy's 5/7.

## Related issues

N/A

## Changes

- `.github/workflows/sla-nag.yml`, daily at 10:00 Manila plus manual dispatch with a `dry_run` input:
  - `ready-for-review` at 5 days: comment asking moderators to ping the reviewer (mentions assignees when set), Discord embed reusing the `notify-reviewer.yml` webhook pattern and enrolled-participants filter.
  - `ready-for-review` at 7 days: escalation comment for the System Lead, Discord embed in red.
  - `needs-improvement` at 7 days: friendly builder nudge with the `/recheck` instruction. No Discord; the ball is with the builder, who gets a GitHub notification.
- The clock starts at the most recent `labeled` event for the current state, not issue creation. A resubmission that re-enters review is not instantly "overdue" from its first round.
- Idempotency via marker comments (`<!-- dep-sla:<stage>:<labeled-date> -->`), same convention as the `dep-eval` markers. One comment per stage per review cycle, ever. Discord fires only alongside a newly posted comment, so it inherits the dedup.
- `docs/assets/progress.js` `daysBadge()`: warn at 5, breach at 7, with a comment pointing at the policy.
- A paragraph in `VOLUNTEER_GUIDE.md` noting the reminders are automated now.

## Test plan

- [x] Script body parses (validated the github-script block with an async function constructor).
- [x] Simulated today's run against live data: it would post the 7-day escalation on #148 and builder nudges on #143, #104, #80, #18. Nothing else triggers. Numbers in the follow-up comment.
- [x] `node --check docs/assets/progress.js` passes.
- [ ] After merge: `workflow_dispatch` with `dry_run: true`, compare the log against the simulation, then let the cron run.

## Rollout / follow-up

Degrades cleanly without the Discord secret (comments still post). If the first live run feels too chatty, the thresholds are constants at the top of the workflow. Suggest one `dry_run` dispatch after merge before trusting the cron.

## Screenshots

N/A

## Checklist

- [x] The PR is focused and I reviewed my own changes
- [x] Tests and manual verification are documented above
- [x] Documentation and `CHANGELOG.md` are updated, or are not applicable
- [x] No credentials, private notes, personal data, or internal links are exposed
- [x] Rollout and compatibility considerations are documented, or are not applicable
